### PR TITLE
fix: render correct markup with custom InfiniteScroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "emotion-theming": "10.0.27",
     "flat": "5.0.0",
     "framer-motion": "2.0.0-beta.72",
+    "lodash.throttle": "4.1.1",
     "polished": "3.6.4",
     "ramda": "0.27.0",
     "react": "16.13.1",
@@ -63,6 +64,7 @@
     "@types/debounce-promise": "3.1.2",
     "@types/flat": "5.0.1",
     "@types/jest": "25.2.3",
+    "@types/lodash.throttle": "4.1.6",
     "@types/ramda": "0.27.6",
     "@types/react-helmet": "6.0.0",
     "@types/react-instantsearch-dom": "6.3.0",
@@ -126,7 +128,6 @@
     "prettier": "2.0.5",
     "pretty-quick": "2.0.1",
     "prismjs": "1.20.0",
-    "react-infinite-scroll-component": "5.0.5",
     "react-test-renderer": "16.13.1",
     "sanitize.css": "11.0.1",
     "typescript": "3.9.3"

--- a/src/components/Home/Posts.tsx
+++ b/src/components/Home/Posts.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import * as R from 'ramda';
 import { FormattedMessage } from 'react-intl';
 import { motion, AnimatePresence } from 'framer-motion';
-import InfiniteScroll from 'react-infinite-scroll-component';
+import { InfiniteScroll } from 'components/InfiniteScroll';
 
 import { PostEdge, PostEdges } from '../../types';
 import { PostCard } from '../PostCard';
@@ -67,35 +67,33 @@ export const Posts: React.FC<{
         <FormattedMessage id={chosenSet.localeId} />
       </LatestMessage>
 
-      <PostList>
-        <InfiniteScroll
-          dataLength={chosenSet.posts.length}
-          next={loadMore}
-          hasMore={hasMore}
-          loader={<></>}
-        >
-          <AnimatePresence initial={false}>
-            {chosenSet.posts.map(({ node }: PostEdge, index) => (
-              <motion.li
-                key={node.id}
-                custom={index}
-                variants={itemsAnimationVariants}
-                initial="hidden"
-                animate="visible"
-                exit="hidden"
-                transition={{
-                  opacity: {
-                    stiffness: 1000,
-                    velocity: -200,
-                  },
-                }}
-              >
-                <PostCard postNode={node} />
-              </motion.li>
-            ))}
-          </AnimatePresence>
-        </InfiniteScroll>
-      </PostList>
+      <InfiniteScroll
+        threshold={500}
+        onLoadMore={loadMore}
+        hasMore={hasMore}
+        Component={PostList}
+      >
+        <AnimatePresence initial={false}>
+          {chosenSet.posts.map(({ node }: PostEdge, index) => (
+            <motion.li
+              key={node.id}
+              custom={index}
+              variants={itemsAnimationVariants}
+              initial="hidden"
+              animate="visible"
+              exit="hidden"
+              transition={{
+                opacity: {
+                  stiffness: 1000,
+                  velocity: -100,
+                },
+              }}
+            >
+              <PostCard postNode={node} />
+            </motion.li>
+          ))}
+        </AnimatePresence>
+      </InfiniteScroll>
     </>
   );
 };

--- a/src/components/InfiniteScroll.tsx
+++ b/src/components/InfiniteScroll.tsx
@@ -1,0 +1,78 @@
+/* Reimplementation of https://github.com/jaredpalmer/react-simple-infinite-scroll
+- Fix a bug that Im not able to proper pass a Component;
+- Use functional component;
+- Use hooks
+- reduce component size
+*/
+import * as React from 'react';
+import throttle from 'lodash.throttle';
+
+export interface InfiniteScrollProps {
+  Component: React.ElementType;
+  /**
+   * Does the resource have more entities
+   */
+  hasMore: boolean;
+  /**
+   * if it's loading or not
+   */
+  isLoading?: boolean;
+  /**
+   * Callback to load more entities
+   */
+  onLoadMore: () => void;
+  /**
+   * Scroll threshold
+   */
+  threshold?: number;
+  /**
+   * Throttle rate
+   */
+  throttleAmount?: number;
+}
+
+export const InfiniteScroll: React.FC<InfiniteScrollProps> = ({
+  Component,
+  children,
+  isLoading,
+  hasMore,
+  threshold = 100,
+  throttleAmount = 64,
+  onLoadMore,
+}) => {
+  const wardRef = React.useRef<HTMLDivElement | null>(null);
+
+  function checkWindowScroll(): void {
+    if (isLoading) {
+      return;
+    }
+
+    if (
+      hasMore &&
+      wardRef.current!.getBoundingClientRect().top - window.innerHeight <
+        threshold!
+    ) {
+      onLoadMore();
+    }
+  }
+
+  React.useEffect(() => {
+    const scrollHandler = throttle(checkWindowScroll, throttleAmount);
+    const resizeHandler = throttle(checkWindowScroll, throttleAmount);
+
+    window.addEventListener('scroll', scrollHandler);
+    window.addEventListener('resize', resizeHandler);
+
+    return () => {
+      window.removeEventListener('scroll', scrollHandler);
+      window.removeEventListener('resize', resizeHandler);
+    };
+  }, []);
+
+  return (
+    <Component>
+      {children}
+      <div ref={wardRef}></div>
+    </Component>
+  );
+};

--- a/types/graphql-types.ts
+++ b/types/graphql-types.ts
@@ -3724,6 +3724,8 @@ export type SitePageFieldsEnum =
   | 'pluginCreator___pluginOptions___path'
   | 'pluginCreator___pluginOptions___name'
   | 'pluginCreator___pluginOptions___fileName'
+  | 'pluginCreator___pluginOptions___sidebar___hidden'
+  | 'pluginCreator___pluginOptions___sidebar___position'
   | 'pluginCreator___pluginOptions___short_name'
   | 'pluginCreator___pluginOptions___start_url'
   | 'pluginCreator___pluginOptions___background_color'
@@ -3746,8 +3748,6 @@ export type SitePageFieldsEnum =
   | 'pluginCreator___pluginOptions___aliases___mdx'
   | 'pluginCreator___pluginOptions___google___families'
   | 'pluginCreator___pluginOptions___pathCheck'
-  | 'pluginCreator___pluginOptions___sidebar___hidden'
-  | 'pluginCreator___pluginOptions___sidebar___position'
   | 'pluginCreator___nodeAPIs'
   | 'pluginCreator___browserAPIs'
   | 'pluginCreator___ssrAPIs'
@@ -3946,6 +3946,8 @@ export type SitePluginFieldsEnum =
   | 'pluginOptions___path'
   | 'pluginOptions___name'
   | 'pluginOptions___fileName'
+  | 'pluginOptions___sidebar___hidden'
+  | 'pluginOptions___sidebar___position'
   | 'pluginOptions___short_name'
   | 'pluginOptions___start_url'
   | 'pluginOptions___background_color'
@@ -3968,8 +3970,6 @@ export type SitePluginFieldsEnum =
   | 'pluginOptions___aliases___mdx'
   | 'pluginOptions___google___families'
   | 'pluginOptions___pathCheck'
-  | 'pluginOptions___sidebar___hidden'
-  | 'pluginOptions___sidebar___position'
   | 'nodeAPIs'
   | 'browserAPIs'
   | 'ssrAPIs'
@@ -4089,6 +4089,7 @@ export type SitePluginPluginOptions = {
   path?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   fileName?: Maybe<Scalars['String']>;
+  sidebar?: Maybe<SitePluginPluginOptionsSidebar>;
   short_name?: Maybe<Scalars['String']>;
   start_url?: Maybe<Scalars['String']>;
   background_color?: Maybe<Scalars['String']>;
@@ -4105,7 +4106,6 @@ export type SitePluginPluginOptions = {
   aliases?: Maybe<SitePluginPluginOptionsAliases>;
   google?: Maybe<SitePluginPluginOptionsGoogle>;
   pathCheck?: Maybe<Scalars['Boolean']>;
-  sidebar?: Maybe<SitePluginPluginOptionsSidebar>;
 };
 
 export type SitePluginPluginOptionsAliases = {
@@ -4127,6 +4127,7 @@ export type SitePluginPluginOptionsFilterInput = {
   path?: Maybe<StringQueryOperatorInput>;
   name?: Maybe<StringQueryOperatorInput>;
   fileName?: Maybe<StringQueryOperatorInput>;
+  sidebar?: Maybe<SitePluginPluginOptionsSidebarFilterInput>;
   short_name?: Maybe<StringQueryOperatorInput>;
   start_url?: Maybe<StringQueryOperatorInput>;
   background_color?: Maybe<StringQueryOperatorInput>;
@@ -4143,7 +4144,6 @@ export type SitePluginPluginOptionsFilterInput = {
   aliases?: Maybe<SitePluginPluginOptionsAliasesFilterInput>;
   google?: Maybe<SitePluginPluginOptionsGoogleFilterInput>;
   pathCheck?: Maybe<BooleanQueryOperatorInput>;
-  sidebar?: Maybe<SitePluginPluginOptionsSidebarFilterInput>;
 };
 
 export type SitePluginPluginOptionsGoogle = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3435,6 +3435,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.throttle@4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.throttle/-/lodash.throttle-4.1.6.tgz#f5ba2c22244ee42ff6c2c49e614401a870c1009c"
+  integrity sha512-/UIH96i/sIRYGC60NoY72jGkCJtFN5KVPhEMMMTjol65effe1gPn0tycJqV5tlSwMTzX8FqzB5yAj0rfGHTPNg==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash@*":
   version "4.14.154"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.154.tgz#069e3c703fdb264e67be9e03b20a640bc0198ecc"
@@ -12898,7 +12905,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash.throttle@^4.1.1:
+lodash.throttle@4.1.1, lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
@@ -16080,13 +16087,6 @@ react-icons@^3.10.0:
   integrity sha512-WsQ5n1JToG9VixWilSo1bHv842Cj5aZqTGiS3Ud47myF6aK7S/IUY2+dHcBdmkQcCFRuHsJ9OMUI0kTDfjyZXQ==
   dependencies:
     camelcase "^5.0.0"
-
-react-infinite-scroll-component@5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/react-infinite-scroll-component/-/react-infinite-scroll-component-5.0.5.tgz#6e4b2bd53f5da0ec3d46eca9661b086dbb7fd2b2"
-  integrity sha512-Xsqqo6gp+mtPbJe/j3hRZrVLFT+gA5FpE4i21HsMJo87vrqVSda8PLOeH+Wizp6SIW8MM1NaYvF7lblfG5YeCA==
-  dependencies:
-    throttle-debounce "^2.1.0"
 
 react-instantsearch-core@^6.5.0:
   version "6.5.0"


### PR DESCRIPTION
Closes #607 

The reason I implemented my own "InfiniteScroll" was that the previous package does not support the capability of passing a custom component, always rendering a div (no time to open a PR for that there, I want this fixed right now).

I also tried https://github.com/jaredpalmer/react-simple-infinite-scroll from Jared Palmer but it seems not being maintained anymore and for some reason it was not working correctly when I passed a render function or a Component.

In the end I just convert this simple component to a even simpler solution.