### PR TITLE
FIX: CI deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,11 @@ jobs:
   install-dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Get actual code
+        uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v1
+      - name: Setup Node Environment
+        uses: actions/setup-node@v1
         with:
           node-version: 12
 
@@ -29,15 +31,16 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --pure-lockfile
-        env:
-          CYPRESS_INSTALL_BINARY: 0
 
   build:
     needs: install-dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - name: Get actual code
+        uses: actions/checkout@v2
+
+      - name: Setup Node Environment
+        uses: actions/setup-node@v1
         with:
           node-version: 12
 
@@ -80,12 +83,45 @@ jobs:
           ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
           GATSBY_ALGOLIA_INDEX_NAME: ${{ secrets.GATSBY_ALGOLIA_INDEX_NAME }}
 
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v1.1
+        id: deploy
+        with:
+          publish-dir: './public'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          production-branch: master
+          deploy-message: 'Deploy from GitHub Actions'
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+
+      - name: Cypress run (E2E)
+        uses: cypress-io/github-action@v1
+        with:
+          browser: chrome
+          headless: true
+        env:
+          CYPRESS_BASE_URL: ${{ steps.deploy.outputs.deploy-url }}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: site
+          path: public/**/*
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cache
+          path: .cache/**/*
+
   lint-and-unit:
     needs: install-dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - name: Get actual code
+        uses: actions/checkout@v2
+
+      - name: Setup Node Environment
+        uses: actions/setup-node@v1
         with:
           node-version: 12
 
@@ -111,42 +147,3 @@ jobs:
         run: yarn jest --color
         env:
           CI: true
-
-  deploy-and-e2e:
-    runs-on: ubuntu-latest
-    needs: [lint-and-unit, build]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-
-      - name: Gatsby Cache Folder
-        uses: actions/cache@v2
-        id: gatsby-cache-folder
-        with:
-          path: |
-            .cache
-            public/
-          key: ${{ runner.os }}-cache-gatsby
-          restore-keys: |
-            ${{ runner.os }}-cache-gatsby
-
-      - name: Deploy to Netlify
-        uses: nwtgck/actions-netlify@v1.1
-        id: deploy
-        with:
-          publish-dir: './public'
-          production-branch: master
-          deploy-message: 'Deploy from GitHub Actions'
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-
-      - name: Cypress run
-        uses: cypress-io/github-action@v1
-        with:
-          browser: chrome
-          headless: true
-        env:
-          CYPRESS_BASE_URL: ${{ steps.deploy.outputs.deploy-url }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,20 @@ jobs:
       - name: Run unit tests
         run: yarn jest --color
 
+      - name: Save public folder as artifact
+        uses: actions/upload-artifact@v2
+        # if: github.ref == 'refs/heads/master'
+        with:
+          name: public
+          path: public/**/*
+
+      - name: Save .cache as artifact
+        uses: actions/upload-artifact@v2
+        # if: github.ref == 'refs/heads/master'
+        with:
+          name: .cache
+          path: .cache/**/*
+
       - name: Build
         run: yarn build --log-pages
         env:
@@ -84,17 +98,3 @@ jobs:
         run: yarn cypress run
         env:
           CYPRESS_BASE_URL: ${{ steps.deploy.outputs.deploy-url }}
-
-      - name: Save public folder as artifact
-        uses: actions/upload-artifact@v2
-        if: github.ref == 'refs/heads/master'
-        with:
-          name: public
-          path: public/**/*
-
-      - name: Save .cache as artifact
-        uses: actions/upload-artifact@v2
-        if: github.ref == 'refs/heads/master'
-        with:
-          name: .cache
-          path: .cache/**/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --pure-lockfile
 
-  build:
+  build-deploy-e2e:
     needs: install-dependencies
     runs-on: ubuntu-latest
     steps:
@@ -83,6 +83,41 @@ jobs:
           ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
           GATSBY_ALGOLIA_INDEX_NAME: ${{ secrets.GATSBY_ALGOLIA_INDEX_NAME }}
 
+      - name: Save public folder as artifact
+        uses: actions/upload-artifact@v2
+        # if: github.ref == 'refs/heads/master'
+        with:
+          name: public
+          path: public/**/*
+
+      - name: Save .cache as artifact
+        uses: actions/upload-artifact@v2
+        # if: github.ref == 'refs/heads/master'
+        with:
+          name: .cache
+          path: .cache/**/*
+
+      # These 2 steps is only happening here and not in a another step
+      # Because it seems there's no way to force update a cache.
+      # It means that even if I setup the gatsby cache up here
+      # for the next step it'll use the old version of it.
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v1
+        id: deploy
+        with:
+          publish-dir: './public'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          production-branch: master
+          deploy-message: 'Deploy from GitHub Actions'
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+
+      - name: Cypress run
+        run: yarn cypress run
+        env:
+          CYPRESS_BASE_URL: ${{ steps.deploy.outputs.deploy-url }}
+
   lint-and-unit:
     needs: install-dependencies
     runs-on: ubuntu-latest
@@ -117,72 +152,3 @@ jobs:
         run: yarn jest --color
         env:
           CI: true
-
-  deploy-and-e2e:
-    runs-on: ubuntu-latest
-    needs: [lint-and-unit, build]
-    steps:
-      - name: Check branch code
-        uses: actions/checkout@v2
-
-      - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12
-
-      - name: Yarn cache directory
-        id: yarn-cache-dir
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir.outputs.dir }}
-            **/node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Gatsby Cache Folder
-        uses: actions/cache@v2
-        id: gatsby-public-folder
-        with:
-          path: |
-            public
-            .cache
-          key: ${{ runner.os }}-public-gatsby-${{ github.ref }}
-          restore-keys: |
-            ${{ runner.OS }}-public-gatsby-
-
-      - name: Save public folder as artifact
-        uses: actions/upload-artifact@v2
-        # if: github.ref == 'refs/heads/master'
-        with:
-          name: public
-          path: public/**/*
-
-      - name: Save .cache as artifact
-        uses: actions/upload-artifact@v2
-        # if: github.ref == 'refs/heads/master'
-        with:
-          name: .cache
-          path: .cache/**/*
-
-      - name: Deploy to Netlify
-        uses: nwtgck/actions-netlify@v1
-        id: deploy
-        with:
-          publish-dir: './public'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          production-branch: master
-          deploy-message: 'Deploy from GitHub Actions'
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-
-      - name: Cypress run
-        run: yarn cypress run
-        env:
-          CYPRESS_BASE_URL: ${{ steps.deploy.outputs.deploy-url }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,26 +28,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      # In order to make gatsby incremental build works, it's necessary .cache
-      # and public folder.
-      - name: Gatsby Public Folder
-        uses: actions/cache@v2
-        id: gatsby-public-folder
-        with:
-          path: public
-          key: ${{ runner.os }}-public-gatsby
-          restore-keys: |
-            ${{ runner.OS }}-public-gatsby
-
-      - name: Gatsby Cache Folder
-        uses: actions/cache@v2
-        id: gatsby-cache-folder
-        with:
-          path: .cache
-          key: ${{ runner.os }}-cache-gatsby
-          restore-keys: |
-            ${{ runner.OS }}-cache-gatsby
-
       - name: Install dependencies
         run: yarn install --pure-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Gatsby Cache Folder
         uses: actions/cache@v2
-        id: gatsby-public-folder
+        id: gatsby-cache-folder
         with:
           path: .cache
           key: ${{ runner.os }}-cache-gatsby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,18 +15,18 @@ jobs:
         with:
           node-version: 12
 
-      - name: Print Yarn cache directory
-        id: yarn-cache-dir
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+      # - name: Print Yarn cache directory
+      #   id: yarn-cache-dir
+      #   run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - name: Yarn cache
-        uses: actions/cache@v1
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+      # - name: Yarn cache
+      #   uses: actions/cache@v1
+      #   id: yarn-cache
+      #   with:
+      #     path: ${{ steps.yarn-cache-dir.outputs.dir }}
+      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-yarn-
 
       # In order to make gatsby incremental build works, it's necessary .cache
       # and public folder.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,21 @@ jobs:
         with:
           node-version: 12
 
+      - name: Yarn cache directory
+        id: yarn-cache-dir
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: |
+            ${{ steps.yarn-cache-dir.outputs.dir }}
+            **/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Gatsby Cache Folder
         uses: actions/cache@v2
         id: gatsby-public-folder
@@ -140,6 +155,20 @@ jobs:
           key: ${{ runner.os }}-public-gatsby-${{ github.ref }}
           restore-keys: |
             ${{ runner.OS }}-public-gatsby-
+
+      - name: Save public folder as artifact
+        uses: actions/upload-artifact@v2
+        # if: github.ref == 'refs/heads/master'
+        with:
+          name: public
+          path: public/**/*
+
+      - name: Save .cache as artifact
+        uses: actions/upload-artifact@v2
+        # if: github.ref == 'refs/heads/master'
+        with:
+          name: .cache
+          path: .cache/**/*
 
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Platform Runs
+name: Platform
 
 on: [push]
 
@@ -14,23 +14,27 @@ jobs:
         with:
           node-version: 12
 
-      - name: Print Yarn cache directory
+      - name: Yarn cache directory
         id: yarn-cache-dir
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: Yarn cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         id: yarn-cache
         with:
-          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          path: |
+            ${{ steps.yarn-cache-dir.outputs.dir }}
+            **/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: Install dependencies
         run: yarn install --pure-lockfile
 
-  lint-and-unit:
-    runs-on: ubuntu-latest
+  build:
     needs: install-dependencies
+    runs-on: ubuntu-latest
     steps:
       - name: Check branch code
         uses: actions/checkout@v2
@@ -40,51 +44,22 @@ jobs:
         with:
           node-version: 12
 
-      - name: Print Yarn cache directory
+      - name: Yarn cache directory
         id: yarn-cache-dir
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: Yarn cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         id: yarn-cache
         with:
-          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          path: |
+            ${{ steps.yarn-cache-dir.outputs.dir }}
+            **/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Run ESLint
-        run: yarn lint
-
-      - name: Run unit tests
-        run: yarn jest --color
-
-  build-and-e2e:
-    runs-on: ubuntu-latest
-    needs: install-dependencies
-    steps:
-      - name: Check branch code
-        uses: actions/checkout@v2
-
-      - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12
-
-      - name: Print Yarn cache directory
-        id: yarn-cache-dir
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Yarn cache
-        uses: actions/cache@v1
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Gatsby Public Folder
+      - name: Gatsby Cache Folder
         uses: actions/cache@v2
         id: gatsby-public-folder
         with:
@@ -94,20 +69,6 @@ jobs:
           key: ${{ runner.os }}-public-gatsby-${{ github.ref }}
           restore-keys: |
             ${{ runner.OS }}-public-gatsby-
-
-      - name: Save public folder as artifact
-        uses: actions/upload-artifact@v2
-        if: github.ref == 'refs/heads/master'
-        with:
-          name: public
-          path: public/**/*
-
-      - name: Save .cache as artifact
-        uses: actions/upload-artifact@v2
-        if: github.ref == 'refs/heads/master'
-        with:
-          name: .cache
-          path: .cache/**/*
 
       - name: Build
         run: yarn build --log-pages
@@ -121,6 +82,64 @@ jobs:
           GATSBY_ALGOLIA_SEARCH_KEY: ${{ secrets.GATSBY_ALGOLIA_SEARCH_KEY }}
           ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
           GATSBY_ALGOLIA_INDEX_NAME: ${{ secrets.GATSBY_ALGOLIA_INDEX_NAME }}
+
+  lint-and-unit:
+    needs: install-dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch code
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Yarn cache directory
+        id: yarn-cache-dir
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: |
+            ${{ steps.yarn-cache-dir.outputs.dir }}
+            **/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Run ESLint
+        run: yarn lint
+
+      - name: Run Test
+        run: yarn jest --color
+        env:
+          CI: true
+
+  deploy-and-e2e:
+    runs-on: ubuntu-latest
+    needs: [lint-and-unit, build]
+    steps:
+      - name: Check branch code
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Gatsby Cache Folder
+        uses: actions/cache@v2
+        id: gatsby-public-folder
+        with:
+          path: |
+            public
+            .cache
+          key: ${{ runner.os }}-public-gatsby-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.OS }}-public-gatsby-
 
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         id: gatsby-public-folder
         with:
           path: public
-          key: ${{ runner.os }}-public-gatsby
+          key: ${{ runner.os }}-public-gatsby-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.OS }}-public-gatsby
 
@@ -42,7 +42,7 @@ jobs:
         id: gatsby-cache-folder
         with:
           path: .cache
-          key: ${{ runner.os }}-cache-gatsby
+          key: ${{ runner.os }}-cache-gatsby-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.OS }}-cache-gatsby
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,67 @@ name: Platform Runs
 on: [push]
 
 jobs:
-  pipeline:
+  install-dependencies:
     runs-on: ubuntu-latest
+    steps:
+      - name: Check branch code
+        uses: actions/checkout@v2
 
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Print Yarn cache directory
+        id: yarn-cache-dir
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Yarn cache
+        uses: actions/cache@v1
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: yarn install --pure-lockfile
+
+  lint-and-unit:
+    runs-on: ubuntu-latest
+    needs: install-dependencies
+    steps:
+      - name: Check branch code
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Print Yarn cache directory
+        id: yarn-cache-dir
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Yarn cache
+        uses: actions/cache@v1
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Run ESLint
+        run: yarn lint
+
+      - name: Run unit tests
+        run: yarn jest --color
+
+  build-and-e2e:
+    runs-on: ubuntu-latest
+    needs: install-dependencies
     steps:
       - name: Check branch code
         uses: actions/checkout@v2
@@ -39,38 +97,16 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-public-gatsby-
 
-      # - name: Gatsby Cache Folder
-      #   uses: actions/cache@v2
-      #   id: gatsby-cache-folder
-      #   with:
-      #     path: .cache
-      #     key: ${{ runner.os }}-cache-gatsby-${{ github.ref }}
-      #     restore-keys: |
-      #       ${{ runner.OS }}-cache-gatsby-
-
-      # - name: Clean gatsby if both didn't hit
-      #   if: steps.gatsby-public-folder.outputs.cache-hit != 'true' || steps.gatsby-cache-folder.outputs.cache-hit != 'true'
-      #   run: rm -rf .cache/ public/
-
-      - name: Install dependencies
-        run: yarn install --pure-lockfile
-
-      - name: Run ESLint
-        run: yarn lint
-
-      - name: Run unit tests
-        run: yarn jest --color
-
       - name: Save public folder as artifact
         uses: actions/upload-artifact@v2
-        # if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         with:
           name: public
           path: public/**/*
 
       - name: Save .cache as artifact
         uses: actions/upload-artifact@v2
-        # if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         with:
           name: .cache
           path: .cache/**/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: Gatsby Public Folder
+        uses: actions/cache@v2
+        id: gatsby-public-folder
+        with:
+          path: public
+          key: ${{ runner.os }}-public-gatsby
+          restore-keys: |
+            ${{ runner.OS }}-public-gatsby
+
+      - name: Gatsby Cache Folder
+        uses: actions/cache@v2
+        id: gatsby-cache-folder
+        with:
+          path: .cache
+          key: ${{ runner.os }}-cache-gatsby
+          restore-keys: |
+            ${{ runner.OS }}-cache-gatsby
+
       - name: Install dependencies
         run: yarn install --pure-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,20 +30,13 @@ jobs:
 
       # In order to make gatsby incremental build works, it's necessary .cache
       # and public folder.
-      - name: Gatsby Cache Folder
-        uses: actions/cache@v2
-        id: gatsby-cache-folder
-        with:
-          path: .cache
-          key: ${{ runner.os }}-cache-gatsby
-          restore-keys: |
-            ${{ runner.os }}-cache-gatsby
-
       - name: Gatsby Public Folder
         uses: actions/cache@v2
         id: gatsby-public-folder
         with:
-          path: public/
+          path: |
+            public
+            .cache
           key: ${{ runner.os }}-public-gatsby
           restore-keys: |
             ${{ runner.OS }}-public-gatsby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,75 +1,61 @@
-name: Platform
+name: Platform Runs
 
 on: [push]
 
 jobs:
-  install-dependencies:
+  pipeline:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Get actual code
+      - name: Check branch code
         uses: actions/checkout@v2
 
-      - name: Setup Node Environment
+      - name: Setup Node
         uses: actions/setup-node@v1
         with:
           node-version: 12
 
-      - name: Yarn cache directory
+      - name: Print Yarn cache directory
         id: yarn-cache-dir
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: Yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@v1
         id: yarn-cache
         with:
-          path: |
-            ${{ steps.yarn-cache-dir.outputs.dir }}
-            **/node_modules
-            ~/.cache
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
+      # In order to make gatsby incremental build works, it's necessary .cache
+      # and public folder.
+      - name: Gatsby Cache Folder
+        uses: actions/cache@v1
+        id: gatsby-cache-folder
+        with:
+          path: .cache
+          key: ${{ runner.os }}-cache-gatsby
+          restore-keys: |
+            ${{ runner.os }}-cache-gatsby
+
+      - name: Gatsby Public Folder
+        uses: actions/cache@v1
+        id: gatsby-public-folder
+        with:
+          path: public/
+          key: ${{ runner.os }}-public-gatsby
+          restore-keys: |
+            ${{ runner.OS }}-public-gatsby
 
       - name: Install dependencies
         run: yarn install --pure-lockfile
 
-  build:
-    needs: install-dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get actual code
-        uses: actions/checkout@v2
+      - name: Run ESLint
+        run: yarn lint
 
-      - name: Setup Node Environment
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12
-
-      - name: Yarn cache directory
-        id: yarn-cache-dir
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir.outputs.dir }}
-            **/node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Gatsby Cache Folder
-        uses: actions/cache@v2
-        id: gatsby-cache-folder
-        with:
-          path: |
-            .cache
-            public/
-          key: ${{ runner.os }}-cache-gatsby
-          restore-keys: |
-            ${{ runner.os }}-cache-gatsby
+      - name: Run unit tests
+        run: yarn jest --color
 
       - name: Build
         run: yarn build --log-pages
@@ -85,7 +71,7 @@ jobs:
           GATSBY_ALGOLIA_INDEX_NAME: ${{ secrets.GATSBY_ALGOLIA_INDEX_NAME }}
 
       - name: Deploy to Netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v1
         id: deploy
         with:
           publish-dir: './public'
@@ -96,52 +82,14 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
-      - name: Cypress run (E2E)
-        run: yarn cypress run
-        env:
-          CYPRESS_BASE_URL: ${{ steps.deploy.outputs.deploy-url }}
-
-      - uses: actions/upload-artifact@v2
+      - name: Save public folder as artifact
+        uses: actions/upload-artifact@v2
         with:
-          name: site
+          name: public
           path: public/**/*
 
-      - uses: actions/upload-artifact@v2
+      - name: Save .cache as artifact
+        uses: actions/upload-artifact@v2
         with:
-          name: cache
+          name: .cache
           path: .cache/**/*
-
-  lint-and-unit:
-    needs: install-dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get actual code
-        uses: actions/checkout@v2
-
-      - name: Setup Node Environment
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12
-
-      - name: Yarn cache directory
-        id: yarn-cache-dir
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir.outputs.dir }}
-            **/node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Run ESLint
-        run: yarn lint
-
-      - name: Run Test
-        run: yarn jest --color
-        env:
-          CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,23 +30,23 @@ jobs:
 
       # In order to make gatsby incremental build works, it's necessary .cache
       # and public folder.
-      # - name: Gatsby Cache Folder
-      #   uses: actions/cache@v1
-      #   id: gatsby-cache-folder
-      #   with:
-      #     path: .cache
-      #     key: ${{ runner.os }}-cache-gatsby
-      #     restore-keys: |
-      #       ${{ runner.os }}-cache-gatsby
+      - name: Gatsby Cache Folder
+        uses: actions/cache@v2
+        id: gatsby-cache-folder
+        with:
+          path: .cache
+          key: ${{ runner.os }}-cache-gatsby
+          restore-keys: |
+            ${{ runner.os }}-cache-gatsby
 
-      # - name: Gatsby Public Folder
-      #   uses: actions/cache@v1
-      #   id: gatsby-public-folder
-      #   with:
-      #     path: public/
-      #     key: ${{ runner.os }}-public-gatsby
-      #     restore-keys: |
-      #       ${{ runner.OS }}-public-gatsby
+      - name: Gatsby Public Folder
+        uses: actions/cache@v2
+        id: gatsby-public-folder
+        with:
+          path: public/
+          key: ${{ runner.os }}-public-gatsby
+          restore-keys: |
+            ${{ runner.OS }}-public-gatsby
 
       - name: Install dependencies
         run: yarn install --pure-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,18 +33,18 @@ jobs:
         id: gatsby-public-folder
         with:
           path: public
-          key: ${{ runner.os }}-public-gatsby-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-public-gatsby-${{ github.ref }}
           restore-keys: |
-            ${{ runner.OS }}-public-gatsby
+            ${{ runner.OS }}-public-gatsby-
 
       - name: Gatsby Cache Folder
         uses: actions/cache@v2
         id: gatsby-cache-folder
         with:
           path: .cache
-          key: ${{ runner.os }}-cache-gatsby-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-cache-gatsby-${{ github.ref }}
           restore-keys: |
-            ${{ runner.OS }}-cache-gatsby
+            ${{ runner.OS }}-cache-gatsby-
 
       - name: Install dependencies
         run: yarn install --pure-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,10 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-cache-gatsby-
 
+      - name: Clean gatsby if both didn't hit
+        if: steps.gatsby-public-folder.outputs.cache-hit != 'true' || steps.gatsby-cache-folder.outputs.cache-hit != 'true'
+        run: rm -rf .cache/ public/
+
       - name: Install dependencies
         run: yarn install --pure-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,23 +32,25 @@ jobs:
         uses: actions/cache@v2
         id: gatsby-public-folder
         with:
-          path: public
+          path: |
+            public
+            .cache
           key: ${{ runner.os }}-public-gatsby-${{ github.ref }}
           restore-keys: |
             ${{ runner.OS }}-public-gatsby-
 
-      - name: Gatsby Cache Folder
-        uses: actions/cache@v2
-        id: gatsby-cache-folder
-        with:
-          path: .cache
-          key: ${{ runner.os }}-cache-gatsby-${{ github.ref }}
-          restore-keys: |
-            ${{ runner.OS }}-cache-gatsby-
+      # - name: Gatsby Cache Folder
+      #   uses: actions/cache@v2
+      #   id: gatsby-cache-folder
+      #   with:
+      #     path: .cache
+      #     key: ${{ runner.os }}-cache-gatsby-${{ github.ref }}
+      #     restore-keys: |
+      #       ${{ runner.OS }}-cache-gatsby-
 
-      - name: Clean gatsby if both didn't hit
-        if: steps.gatsby-public-folder.outputs.cache-hit != 'true' || steps.gatsby-cache-folder.outputs.cache-hit != 'true'
-        run: rm -rf .cache/ public/
+      # - name: Clean gatsby if both didn't hit
+      #   if: steps.gatsby-public-folder.outputs.cache-hit != 'true' || steps.gatsby-cache-folder.outputs.cache-hit != 'true'
+      #   run: rm -rf .cache/ public/
 
       - name: Install dependencies
         run: yarn install --pure-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,19 @@ jobs:
         uses: actions/cache@v2
         id: gatsby-public-folder
         with:
-          path: |
-            public
-            .cache
+          path: public
           key: ${{ runner.os }}-public-gatsby
           restore-keys: |
             ${{ runner.OS }}-public-gatsby
+
+      - name: Gatsby Cache Folder
+        uses: actions/cache@v2
+        id: gatsby-public-folder
+        with:
+          path: .cache
+          key: ${{ runner.os }}-cache-gatsby
+          restore-keys: |
+            ${{ runner.OS }}-cache-gatsby
 
       - name: Install dependencies
         run: yarn install --pure-lockfile
@@ -82,12 +89,14 @@ jobs:
 
       - name: Save public folder as artifact
         uses: actions/upload-artifact@v2
+        if: github.ref == 'refs/heads/master'
         with:
           name: public
           path: public/**/*
 
       - name: Save .cache as artifact
         uses: actions/upload-artifact@v2
+        if: github.ref == 'refs/heads/master'
         with:
           name: .cache
           path: .cache/**/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
 
       - name: Install dependencies
         run: yarn install --pure-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           path: |
             ${{ steps.yarn-cache-dir.outputs.dir }}
             **/node_modules
+            ~/.cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
@@ -96,10 +97,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
       - name: Cypress run (E2E)
-        uses: cypress-io/github-action@v1
-        with:
-          browser: chrome
-          headless: true
+        run: yarn cypress run
         env:
           CYPRESS_BASE_URL: ${{ steps.deploy.outputs.deploy-url }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,38 +15,38 @@ jobs:
         with:
           node-version: 12
 
-      # - name: Print Yarn cache directory
-      #   id: yarn-cache-dir
-      #   run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Print Yarn cache directory
+        id: yarn-cache-dir
+        run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      # - name: Yarn cache
-      #   uses: actions/cache@v1
-      #   id: yarn-cache
-      #   with:
-      #     path: ${{ steps.yarn-cache-dir.outputs.dir }}
-      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-yarn-
+      - name: Yarn cache
+        uses: actions/cache@v1
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       # In order to make gatsby incremental build works, it's necessary .cache
       # and public folder.
-      - name: Gatsby Cache Folder
-        uses: actions/cache@v1
-        id: gatsby-cache-folder
-        with:
-          path: .cache
-          key: ${{ runner.os }}-cache-gatsby
-          restore-keys: |
-            ${{ runner.os }}-cache-gatsby
+      # - name: Gatsby Cache Folder
+      #   uses: actions/cache@v1
+      #   id: gatsby-cache-folder
+      #   with:
+      #     path: .cache
+      #     key: ${{ runner.os }}-cache-gatsby
+      #     restore-keys: |
+      #       ${{ runner.os }}-cache-gatsby
 
-      - name: Gatsby Public Folder
-        uses: actions/cache@v1
-        id: gatsby-public-folder
-        with:
-          path: public/
-          key: ${{ runner.os }}-public-gatsby
-          restore-keys: |
-            ${{ runner.OS }}-public-gatsby
+      # - name: Gatsby Public Folder
+      #   uses: actions/cache@v1
+      #   id: gatsby-public-folder
+      #   with:
+      #     path: public/
+      #     key: ${{ runner.os }}-public-gatsby
+      #     restore-keys: |
+      #       ${{ runner.OS }}-public-gatsby
 
       - name: Install dependencies
         run: yarn install --pure-lockfile
@@ -81,6 +81,11 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+
+      - name: Cypress run
+        run: yarn cypress run
+        env:
+          CYPRESS_BASE_URL: ${{ steps.deploy.outputs.deploy-url }}
 
       - name: Save public folder as artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           path: |
             ${{ steps.yarn-cache-dir.outputs.dir }}
             **/node_modules
+            ~/.cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
@@ -55,6 +56,7 @@ jobs:
           path: |
             ${{ steps.yarn-cache-dir.outputs.dir }}
             **/node_modules
+            ~/.cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
@@ -141,6 +143,7 @@ jobs:
           path: |
             ${{ steps.yarn-cache-dir.outputs.dir }}
             **/node_modules
+            ~/.cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-

--- a/src/templates/home.tsx
+++ b/src/templates/home.tsx
@@ -51,6 +51,7 @@ const HomeTemplate: React.FC<HomeTemplateType> = ({ pageContext }) => {
 
       <Layout>
         <main>
+          <h1>hoho</h1>
           <AuthorPresentation />
           <Filter setFilter={setFilter} currentFilter={filter} />
           <Posts

--- a/src/templates/home.tsx
+++ b/src/templates/home.tsx
@@ -51,7 +51,7 @@ const HomeTemplate: React.FC<HomeTemplateType> = ({ pageContext }) => {
 
       <Layout>
         <main>
-          <h1>hoho</h1>
+          <h1>heyho</h1>
           <AuthorPresentation />
           <Filter setFilter={setFilter} currentFilter={filter} />
           <Posts

--- a/src/templates/home.tsx
+++ b/src/templates/home.tsx
@@ -51,7 +51,6 @@ const HomeTemplate: React.FC<HomeTemplateType> = ({ pageContext }) => {
 
       <Layout>
         <main>
-          <h1>heyho</h1>
           <AuthorPresentation />
           <Filter setFilter={setFilter} currentFilter={filter} />
           <Posts

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,5 +28,6 @@
       "layouts/*": ["src/layouts/*"]
     }
   },
-  "typeRoots": ["node_modules/@types", "types", "cypress"]
+  "typeRoots": ["node_modules/@types", "types", "cypress"],
+  "exclude": [".cache", "public", "node_modules"]
 }

--- a/types/graphql-types.ts
+++ b/types/graphql-types.ts
@@ -1255,12 +1255,12 @@ export type FileFieldsEnum =
   | 'childMdx___frontmatter___image___publicURL'
   | 'childMdx___frontmatter___image___id'
   | 'childMdx___frontmatter___image___children'
+  | 'childMdx___frontmatter___image_caption'
   | 'childMdx___frontmatter___description'
   | 'childMdx___frontmatter___categories'
   | 'childMdx___frontmatter___series___id'
   | 'childMdx___frontmatter___series___index'
   | 'childMdx___frontmatter___series___copy'
-  | 'childMdx___frontmatter___image_caption'
   | 'childMdx___body'
   | 'childMdx___excerpt'
   | 'childMdx___headings'
@@ -2163,12 +2163,12 @@ export type MdxFieldsEnum =
   | 'frontmatter___image___childCvJson___lang'
   | 'frontmatter___image___childCvJson___rawJson'
   | 'frontmatter___image___childCvJson___fileRelativePath'
+  | 'frontmatter___image_caption'
   | 'frontmatter___description'
   | 'frontmatter___categories'
   | 'frontmatter___series___id'
   | 'frontmatter___series___index'
   | 'frontmatter___series___copy'
-  | 'frontmatter___image_caption'
   | 'body'
   | 'excerpt'
   | 'headings'
@@ -2301,10 +2301,10 @@ export type MdxFrontmatter = {
   subtitle?: Maybe<Scalars['String']>;
   date?: Maybe<Scalars['Date']>;
   image?: Maybe<File>;
+  image_caption?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   categories?: Maybe<Array<Maybe<Scalars['String']>>>;
   series?: Maybe<MdxFrontmatterSeries>;
-  image_caption?: Maybe<Scalars['String']>;
 };
 
 
@@ -2320,10 +2320,10 @@ export type MdxFrontmatterFilterInput = {
   subtitle?: Maybe<StringQueryOperatorInput>;
   date?: Maybe<DateQueryOperatorInput>;
   image?: Maybe<FileFilterInput>;
+  image_caption?: Maybe<StringQueryOperatorInput>;
   description?: Maybe<StringQueryOperatorInput>;
   categories?: Maybe<StringQueryOperatorInput>;
   series?: Maybe<MdxFrontmatterSeriesFilterInput>;
-  image_caption?: Maybe<StringQueryOperatorInput>;
 };
 
 export type MdxFrontmatterSeries = {
@@ -2580,6 +2580,8 @@ export type QueryAllSitePageArgs = {
 export type QuerySiteArgs = {
   buildTime?: Maybe<DateQueryOperatorInput>;
   siteMetadata?: Maybe<SiteSiteMetadataFilterInput>;
+  port?: Maybe<DateQueryOperatorInput>;
+  host?: Maybe<StringQueryOperatorInput>;
   polyfill?: Maybe<BooleanQueryOperatorInput>;
   pathPrefix?: Maybe<StringQueryOperatorInput>;
   id?: Maybe<StringQueryOperatorInput>;
@@ -2718,6 +2720,8 @@ export type QueryAllSitePluginArgs = {
 export type Site = Node & {
   buildTime?: Maybe<Scalars['Date']>;
   siteMetadata?: Maybe<SiteSiteMetadata>;
+  port?: Maybe<Scalars['Date']>;
+  host?: Maybe<Scalars['String']>;
   polyfill?: Maybe<Scalars['Boolean']>;
   pathPrefix?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
@@ -2728,6 +2732,14 @@ export type Site = Node & {
 
 
 export type SiteBuildTimeArgs = {
+  formatString?: Maybe<Scalars['String']>;
+  fromNow?: Maybe<Scalars['Boolean']>;
+  difference?: Maybe<Scalars['String']>;
+  locale?: Maybe<Scalars['String']>;
+};
+
+
+export type SitePortArgs = {
   formatString?: Maybe<Scalars['String']>;
   fromNow?: Maybe<Scalars['Boolean']>;
   difference?: Maybe<Scalars['String']>;
@@ -2924,6 +2936,8 @@ export type SiteFieldsEnum =
   | 'siteMetadata___social___twitter'
   | 'siteMetadata___social___linkedIn'
   | 'siteMetadata___social___github'
+  | 'port'
+  | 'host'
   | 'polyfill'
   | 'pathPrefix'
   | 'id'
@@ -3016,6 +3030,8 @@ export type SiteFieldsEnum =
 export type SiteFilterInput = {
   buildTime?: Maybe<DateQueryOperatorInput>;
   siteMetadata?: Maybe<SiteSiteMetadataFilterInput>;
+  port?: Maybe<DateQueryOperatorInput>;
+  host?: Maybe<StringQueryOperatorInput>;
   polyfill?: Maybe<BooleanQueryOperatorInput>;
   pathPrefix?: Maybe<StringQueryOperatorInput>;
   id?: Maybe<StringQueryOperatorInput>;
@@ -3708,8 +3724,6 @@ export type SitePageFieldsEnum =
   | 'pluginCreator___pluginOptions___path'
   | 'pluginCreator___pluginOptions___name'
   | 'pluginCreator___pluginOptions___fileName'
-  | 'pluginCreator___pluginOptions___sidebar___hidden'
-  | 'pluginCreator___pluginOptions___sidebar___position'
   | 'pluginCreator___pluginOptions___short_name'
   | 'pluginCreator___pluginOptions___start_url'
   | 'pluginCreator___pluginOptions___background_color'
@@ -3732,6 +3746,8 @@ export type SitePageFieldsEnum =
   | 'pluginCreator___pluginOptions___aliases___mdx'
   | 'pluginCreator___pluginOptions___google___families'
   | 'pluginCreator___pluginOptions___pathCheck'
+  | 'pluginCreator___pluginOptions___sidebar___hidden'
+  | 'pluginCreator___pluginOptions___sidebar___position'
   | 'pluginCreator___nodeAPIs'
   | 'pluginCreator___browserAPIs'
   | 'pluginCreator___ssrAPIs'
@@ -3930,8 +3946,6 @@ export type SitePluginFieldsEnum =
   | 'pluginOptions___path'
   | 'pluginOptions___name'
   | 'pluginOptions___fileName'
-  | 'pluginOptions___sidebar___hidden'
-  | 'pluginOptions___sidebar___position'
   | 'pluginOptions___short_name'
   | 'pluginOptions___start_url'
   | 'pluginOptions___background_color'
@@ -3954,6 +3968,8 @@ export type SitePluginFieldsEnum =
   | 'pluginOptions___aliases___mdx'
   | 'pluginOptions___google___families'
   | 'pluginOptions___pathCheck'
+  | 'pluginOptions___sidebar___hidden'
+  | 'pluginOptions___sidebar___position'
   | 'nodeAPIs'
   | 'browserAPIs'
   | 'ssrAPIs'
@@ -4073,7 +4089,6 @@ export type SitePluginPluginOptions = {
   path?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   fileName?: Maybe<Scalars['String']>;
-  sidebar?: Maybe<SitePluginPluginOptionsSidebar>;
   short_name?: Maybe<Scalars['String']>;
   start_url?: Maybe<Scalars['String']>;
   background_color?: Maybe<Scalars['String']>;
@@ -4090,6 +4105,7 @@ export type SitePluginPluginOptions = {
   aliases?: Maybe<SitePluginPluginOptionsAliases>;
   google?: Maybe<SitePluginPluginOptionsGoogle>;
   pathCheck?: Maybe<Scalars['Boolean']>;
+  sidebar?: Maybe<SitePluginPluginOptionsSidebar>;
 };
 
 export type SitePluginPluginOptionsAliases = {
@@ -4111,7 +4127,6 @@ export type SitePluginPluginOptionsFilterInput = {
   path?: Maybe<StringQueryOperatorInput>;
   name?: Maybe<StringQueryOperatorInput>;
   fileName?: Maybe<StringQueryOperatorInput>;
-  sidebar?: Maybe<SitePluginPluginOptionsSidebarFilterInput>;
   short_name?: Maybe<StringQueryOperatorInput>;
   start_url?: Maybe<StringQueryOperatorInput>;
   background_color?: Maybe<StringQueryOperatorInput>;
@@ -4128,6 +4143,7 @@ export type SitePluginPluginOptionsFilterInput = {
   aliases?: Maybe<SitePluginPluginOptionsAliasesFilterInput>;
   google?: Maybe<SitePluginPluginOptionsGoogleFilterInput>;
   pathCheck?: Maybe<BooleanQueryOperatorInput>;
+  sidebar?: Maybe<SitePluginPluginOptionsSidebarFilterInput>;
 };
 
 export type SitePluginPluginOptionsGoogle = {

--- a/types/graphql-types.ts
+++ b/types/graphql-types.ts
@@ -2580,8 +2580,6 @@ export type QueryAllSitePageArgs = {
 export type QuerySiteArgs = {
   buildTime?: Maybe<DateQueryOperatorInput>;
   siteMetadata?: Maybe<SiteSiteMetadataFilterInput>;
-  port?: Maybe<DateQueryOperatorInput>;
-  host?: Maybe<StringQueryOperatorInput>;
   polyfill?: Maybe<BooleanQueryOperatorInput>;
   pathPrefix?: Maybe<StringQueryOperatorInput>;
   id?: Maybe<StringQueryOperatorInput>;
@@ -2720,8 +2718,6 @@ export type QueryAllSitePluginArgs = {
 export type Site = Node & {
   buildTime?: Maybe<Scalars['Date']>;
   siteMetadata?: Maybe<SiteSiteMetadata>;
-  port?: Maybe<Scalars['Date']>;
-  host?: Maybe<Scalars['String']>;
   polyfill?: Maybe<Scalars['Boolean']>;
   pathPrefix?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
@@ -2732,14 +2728,6 @@ export type Site = Node & {
 
 
 export type SiteBuildTimeArgs = {
-  formatString?: Maybe<Scalars['String']>;
-  fromNow?: Maybe<Scalars['Boolean']>;
-  difference?: Maybe<Scalars['String']>;
-  locale?: Maybe<Scalars['String']>;
-};
-
-
-export type SitePortArgs = {
   formatString?: Maybe<Scalars['String']>;
   fromNow?: Maybe<Scalars['Boolean']>;
   difference?: Maybe<Scalars['String']>;
@@ -2936,8 +2924,6 @@ export type SiteFieldsEnum =
   | 'siteMetadata___social___twitter'
   | 'siteMetadata___social___linkedIn'
   | 'siteMetadata___social___github'
-  | 'port'
-  | 'host'
   | 'polyfill'
   | 'pathPrefix'
   | 'id'
@@ -3030,8 +3016,6 @@ export type SiteFieldsEnum =
 export type SiteFilterInput = {
   buildTime?: Maybe<DateQueryOperatorInput>;
   siteMetadata?: Maybe<SiteSiteMetadataFilterInput>;
-  port?: Maybe<DateQueryOperatorInput>;
-  host?: Maybe<StringQueryOperatorInput>;
   polyfill?: Maybe<BooleanQueryOperatorInput>;
   pathPrefix?: Maybe<StringQueryOperatorInput>;
   id?: Maybe<StringQueryOperatorInput>;
@@ -3724,6 +3708,8 @@ export type SitePageFieldsEnum =
   | 'pluginCreator___pluginOptions___path'
   | 'pluginCreator___pluginOptions___name'
   | 'pluginCreator___pluginOptions___fileName'
+  | 'pluginCreator___pluginOptions___sidebar___hidden'
+  | 'pluginCreator___pluginOptions___sidebar___position'
   | 'pluginCreator___pluginOptions___short_name'
   | 'pluginCreator___pluginOptions___start_url'
   | 'pluginCreator___pluginOptions___background_color'
@@ -3746,8 +3732,6 @@ export type SitePageFieldsEnum =
   | 'pluginCreator___pluginOptions___aliases___mdx'
   | 'pluginCreator___pluginOptions___google___families'
   | 'pluginCreator___pluginOptions___pathCheck'
-  | 'pluginCreator___pluginOptions___sidebar___hidden'
-  | 'pluginCreator___pluginOptions___sidebar___position'
   | 'pluginCreator___nodeAPIs'
   | 'pluginCreator___browserAPIs'
   | 'pluginCreator___ssrAPIs'
@@ -3946,6 +3930,8 @@ export type SitePluginFieldsEnum =
   | 'pluginOptions___path'
   | 'pluginOptions___name'
   | 'pluginOptions___fileName'
+  | 'pluginOptions___sidebar___hidden'
+  | 'pluginOptions___sidebar___position'
   | 'pluginOptions___short_name'
   | 'pluginOptions___start_url'
   | 'pluginOptions___background_color'
@@ -3968,8 +3954,6 @@ export type SitePluginFieldsEnum =
   | 'pluginOptions___aliases___mdx'
   | 'pluginOptions___google___families'
   | 'pluginOptions___pathCheck'
-  | 'pluginOptions___sidebar___hidden'
-  | 'pluginOptions___sidebar___position'
   | 'nodeAPIs'
   | 'browserAPIs'
   | 'ssrAPIs'
@@ -4089,6 +4073,7 @@ export type SitePluginPluginOptions = {
   path?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   fileName?: Maybe<Scalars['String']>;
+  sidebar?: Maybe<SitePluginPluginOptionsSidebar>;
   short_name?: Maybe<Scalars['String']>;
   start_url?: Maybe<Scalars['String']>;
   background_color?: Maybe<Scalars['String']>;
@@ -4105,7 +4090,6 @@ export type SitePluginPluginOptions = {
   aliases?: Maybe<SitePluginPluginOptionsAliases>;
   google?: Maybe<SitePluginPluginOptionsGoogle>;
   pathCheck?: Maybe<Scalars['Boolean']>;
-  sidebar?: Maybe<SitePluginPluginOptionsSidebar>;
 };
 
 export type SitePluginPluginOptionsAliases = {
@@ -4127,6 +4111,7 @@ export type SitePluginPluginOptionsFilterInput = {
   path?: Maybe<StringQueryOperatorInput>;
   name?: Maybe<StringQueryOperatorInput>;
   fileName?: Maybe<StringQueryOperatorInput>;
+  sidebar?: Maybe<SitePluginPluginOptionsSidebarFilterInput>;
   short_name?: Maybe<StringQueryOperatorInput>;
   start_url?: Maybe<StringQueryOperatorInput>;
   background_color?: Maybe<StringQueryOperatorInput>;
@@ -4143,7 +4128,6 @@ export type SitePluginPluginOptionsFilterInput = {
   aliases?: Maybe<SitePluginPluginOptionsAliasesFilterInput>;
   google?: Maybe<SitePluginPluginOptionsGoogleFilterInput>;
   pathCheck?: Maybe<BooleanQueryOperatorInput>;
-  sidebar?: Maybe<SitePluginPluginOptionsSidebarFilterInput>;
 };
 
 export type SitePluginPluginOptionsGoogle = {


### PR DESCRIPTION
Basically after the changes made on #616 , the automatic deployment stopped working.

The problem was put together the caching of `.cache` and  `public` by using `actions cache @v2`.

I had designed the pipeline in way that it could:
1. install dependencies;
2. build (cache public and .cache folder) + (in parallel) unit tests and lint
3. Get cache from build, deploy and run cypress against deploy URL

It was working fine in terms of red/green but the version deployed was always incorrect (maybe was been deployed the production cache).

It seems to fix that I still need to keep caching in 2 steps.


## Investigation

It seems that happens is (for gatbsy):

1. It gets the old cache, that's fine;
1. It builds based on the old cache;
1. In the post cache action, it find a cache hit and do not save the updated cache
![image](https://user-images.githubusercontent.com/12464600/84474957-06573980-ac8c-11ea-8c6b-47ca2167ba92.png)

Consequently what's being used isn't the updated cache but the old one.
