### PR TITLE
feat: Add available translated posts

### DIFF
--- a/helpers/__tests__/__mocks__/createPages.js
+++ b/helpers/__tests__/__mocks__/createPages.js
@@ -22,7 +22,7 @@ const tagPagePosts = {
               fields: {
                 slug: '/en/2020/04/cache-gatsby-github-actions',
                 lang: 'en',
-                commonSlug: '/2020/04/cache-gatsby-github-actions',
+                postFolderName: '/2020/04/cache-gatsby-github-actions',
               },
             },
           },
@@ -45,7 +45,7 @@ const tagPagePosts = {
               fields: {
                 slug: '/2020/03/dev-js-9',
                 lang: 'pt',
-                commonSlug: '/2020/03/dev-js-9',
+                postFolderName: '/2020/03/dev-js-9',
               },
             },
           },
@@ -67,7 +67,7 @@ const tagPagePosts = {
               fields: {
                 slug: '/en/2020/03/yml-for-fe',
                 lang: 'en',
-                commonSlug: '/2020/03/yml-for-fe',
+                postFolderName: '/2020/03/yml-for-fe',
               },
             },
           },
@@ -89,7 +89,7 @@ const tagPagePosts = {
               fields: {
                 slug: '/2020/03/13/corona-virus-overview',
                 lang: 'pt',
-                commonSlug: '/2020/03/13/corona-virus-overview',
+                postFolderName: '/2020/03/13/corona-virus-overview',
               },
             },
           },
@@ -120,7 +120,7 @@ const tagPagePosts = {
               fields: {
                 slug: '/en/2020/04/cache-gatsby-github-actions',
                 lang: 'en',
-                commonSlug: '/2020/04/cache-gatsby-github-actions',
+                postFolderName: '/2020/04/cache-gatsby-github-actions',
               },
             },
           },
@@ -142,7 +142,7 @@ const tagPagePosts = {
               fields: {
                 slug: '/en/2020/03/yml-for-fe',
                 lang: 'en',
-                commonSlug: '/2020/03/yml-for-fe',
+                postFolderName: '/2020/03/yml-for-fe',
               },
             },
           },
@@ -172,7 +172,7 @@ const tagPagePosts = {
               fields: {
                 slug: '/en/2020/04/cache-gatsby-github-actions',
                 lang: 'en',
-                commonSlug: '/2020/04/cache-gatsby-github-actions',
+                postFolderName: '/2020/04/cache-gatsby-github-actions',
               },
             },
           },
@@ -202,7 +202,7 @@ const tagPagePosts = {
               fields: {
                 slug: '/en/2020/04/cache-gatsby-github-actions',
                 lang: 'en',
-                commonSlug: '/2020/04/cache-gatsby-github-actions',
+                postFolderName: '/2020/04/cache-gatsby-github-actions',
               },
             },
           },
@@ -234,7 +234,7 @@ const tagPagePosts = {
               fields: {
                 slug: '/2020/03/dev-js-9',
                 lang: 'pt',
-                commonSlug: '/2020/03/dev-js-9',
+                postFolderName: '/2020/03/dev-js-9',
               },
             },
           },
@@ -266,7 +266,7 @@ const tagPagePosts = {
               fields: {
                 slug: '/2020/03/dev-js-9',
                 lang: 'pt',
-                commonSlug: '/2020/03/dev-js-9',
+                postFolderName: '/2020/03/dev-js-9',
               },
             },
           },
@@ -298,7 +298,7 @@ const tagPagePosts = {
               fields: {
                 slug: '/2020/03/dev-js-9',
                 lang: 'pt',
-                commonSlug: '/2020/03/dev-js-9',
+                postFolderName: '/2020/03/dev-js-9',
               },
             },
           },
@@ -330,7 +330,7 @@ const tagPagePosts = {
               fields: {
                 slug: '/2020/03/dev-js-9',
                 lang: 'pt',
-                commonSlug: '/2020/03/dev-js-9',
+                postFolderName: '/2020/03/dev-js-9',
               },
             },
           },
@@ -361,7 +361,7 @@ const tagPagePosts = {
               fields: {
                 slug: '/en/2020/03/yml-for-fe',
                 lang: 'en',
-                commonSlug: '/2020/03/yml-for-fe',
+                postFolderName: '/2020/03/yml-for-fe',
               },
             },
           },
@@ -392,7 +392,7 @@ const tagPagePosts = {
               fields: {
                 slug: '/en/2020/03/yml-for-fe',
                 lang: 'en',
-                commonSlug: '/2020/03/yml-for-fe',
+                postFolderName: '/2020/03/yml-for-fe',
               },
             },
           },
@@ -423,7 +423,7 @@ const tagPagePosts = {
               fields: {
                 slug: '/2020/03/13/corona-virus-overview',
                 lang: 'pt',
-                commonSlug: '/2020/03/13/corona-virus-overview',
+                postFolderName: '/2020/03/13/corona-virus-overview',
               },
             },
           },
@@ -454,7 +454,7 @@ const tagPagePosts = {
               fields: {
                 slug: '/2020/03/13/corona-virus-overview',
                 lang: 'pt',
-                commonSlug: '/2020/03/13/corona-virus-overview',
+                postFolderName: '/2020/03/13/corona-virus-overview',
               },
             },
           },
@@ -485,7 +485,7 @@ const tagPagePosts = {
               fields: {
                 slug: '/2020/03/13/corona-virus-overview',
                 lang: 'pt',
-                commonSlug: '/2020/03/13/corona-virus-overview',
+                postFolderName: '/2020/03/13/corona-virus-overview',
               },
             },
           },

--- a/helpers/__tests__/createPages.test.js
+++ b/helpers/__tests__/createPages.test.js
@@ -1,4 +1,7 @@
-const { createTagPage } = require('../createPages');
+const {
+  createTagPage,
+  bindPostWithItsTranslations,
+} = require('../createPages');
 const { tagPagePosts } = require('./__mocks__/createPages');
 
 describe('fn: createTagPage', () => {
@@ -13,5 +16,142 @@ describe('fn: createTagPage', () => {
     tagPagePosts.expects.forEach((expectData, index) => {
       expect(createPageMock).toHaveBeenNthCalledWith(index + 1, expectData);
     });
+  });
+});
+
+const mockedData = [
+  {
+    node: {
+      id: '7f826c11-517a-573d-837f-9574af4112ca',
+      fields: {
+        slug: '/blog/pomodoro',
+        lang: 'pt',
+        postFolderName: 'pomodoro',
+      },
+    },
+  },
+  {
+    node: {
+      id: 'a3018a97-cb09-58b1-a5ad-7468fafe96cb',
+      fields: {
+        slug: '/blog/en/cache-gatsby-github-actions',
+        lang: 'en',
+        postFolderName: 'cache-gatsby-github-actions',
+      },
+    },
+  },
+  {
+    node: {
+      id: '205cb9ad-6ce7-5703-bde6-adb40a4de0e1',
+      fields: {
+        slug: '/blog/dev-js-part-9',
+        lang: 'pt',
+        postFolderName: 'dev-js-part-9',
+      },
+    },
+  },
+  {
+    node: {
+      id: '6c594c3f-062d-5fae-86da-732f016e7f11',
+      fields: {
+        slug: '/blog/yml-for-web-dev',
+        lang: 'pt',
+        postFolderName: 'yml-for-web-dev',
+      },
+    },
+  },
+  {
+    node: {
+      id: '9c433d86-5f58-5f13-880c-d40f42afcfe7',
+      fields: {
+        slug: '/blog/en/yml-for-web-dev',
+        lang: 'en',
+        postFolderName: 'yml-for-web-dev',
+      },
+    },
+  },
+];
+
+const expectedData = [
+  {
+    node: {
+      id: '7f826c11-517a-573d-837f-9574af4112ca',
+      fields: {
+        slug: '/blog/pomodoro',
+        lang: 'pt',
+        postFolderName: 'pomodoro',
+      },
+      nonGraphQLData: {
+        translations: null,
+      },
+    },
+  },
+  {
+    node: {
+      id: 'a3018a97-cb09-58b1-a5ad-7468fafe96cb',
+      fields: {
+        slug: '/blog/en/cache-gatsby-github-actions',
+        lang: 'en',
+        postFolderName: 'cache-gatsby-github-actions',
+      },
+      nonGraphQLData: {
+        translations: null,
+      },
+    },
+  },
+  {
+    node: {
+      id: '205cb9ad-6ce7-5703-bde6-adb40a4de0e1',
+      fields: {
+        slug: '/blog/dev-js-part-9',
+        lang: 'pt',
+        postFolderName: 'dev-js-part-9',
+      },
+      nonGraphQLData: {
+        translations: null,
+      },
+    },
+  },
+  {
+    node: {
+      id: '6c594c3f-062d-5fae-86da-732f016e7f11',
+      fields: {
+        slug: '/blog/yml-for-web-dev',
+        lang: 'pt',
+        postFolderName: 'yml-for-web-dev',
+      },
+      nonGraphQLData: {
+        translations: [
+          {
+            lang: 'en',
+            slug: '/blog/en/yml-for-web-dev',
+          },
+        ],
+      },
+    },
+  },
+  {
+    node: {
+      id: '9c433d86-5f58-5f13-880c-d40f42afcfe7',
+      fields: {
+        slug: '/blog/en/yml-for-web-dev',
+        lang: 'en',
+        postFolderName: 'yml-for-web-dev',
+      },
+      nonGraphQLData: {
+        translations: [
+          {
+            lang: 'pt',
+            slug: '/blog/yml-for-web-dev',
+          },
+        ],
+      },
+    },
+  },
+];
+
+describe('fn: bindPostWithItsTranslations', () => {
+  it('returns expected values', () => {
+    expect(bindPostWithItsTranslations(mockedData)).toEqual(expectedData);
   });
 });

--- a/helpers/algolia.js
+++ b/helpers/algolia.js
@@ -12,7 +12,7 @@ const myQuery = `{
         fields {
           slug
           lang
-          commonSlug
+          postFolderName
         }
         frontmatter {
           date

--- a/helpers/createFields.js
+++ b/helpers/createFields.js
@@ -36,11 +36,11 @@ const createFields = ({ node, actions }) => {
       value: postLang,
     });
 
-    /* commonSlug is used to group translated versions of the same post */
+    /* postFolderName is used to group translated versions of the same post */
     createNodeField({
       node,
-      name: `commonSlug`,
-      value: blogPostFolderPath,
+      name: `postFolderName`,
+      value: postPath,
     });
   }
 };

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "remark-unwrap-images": "2.0.0",
     "sanitize.css": "11.0.1",
     "styled-components": "5.1.1",
+    "ts-jest": "26.1.3",
     "typescript": "3.9.6"
   },
   "resolutions": {

--- a/src/components/Blog/AvailableTranslations/AvailableTranslations.test.tsx
+++ b/src/components/Blog/AvailableTranslations/AvailableTranslations.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { mocked } from 'ts-jest/utils';
+
+import { render, screen } from 'test-utils';
+
+import { useBlogContext } from '../blogContext';
+import { AvailableTranslations } from '.';
+
+jest.mock('../blogContext');
+
+const mockedUseBlogContext = mocked(useBlogContext);
+
+describe('<AvailableTranslations />', () => {
+  it('does not render anything if translations is null', () => {
+    mockedUseBlogContext.mockReturnValue({ translations: null } as any);
+    render(<AvailableTranslations />);
+
+    expect(
+      screen.queryByTestId('blog-available-translations'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders links for all available locales', () => {
+    mockedUseBlogContext.mockReturnValue({
+      translations: [
+        { lang: 'pt', slug: '/post' },
+        { lang: 'en', slug: '/en/post' },
+      ],
+    } as any);
+    render(<AvailableTranslations />);
+
+    const linkElements = screen.queryAllByTestId(
+      'blog-available-translations-link',
+    );
+
+    expect(linkElements).toHaveLength(2);
+    expect(linkElements).toMatchInlineSnapshot(`
+      Array [
+        <a
+          data-testid="blog-available-translations-link"
+          href="/post"
+        >
+          Portuguese
+        </a>,
+        <a
+          data-testid="blog-available-translations-link"
+          href="/en/post"
+        >
+          English
+        </a>,
+      ]
+    `);
+  });
+});

--- a/src/components/Blog/AvailableTranslations/AvailableTranslations.tsx
+++ b/src/components/Blog/AvailableTranslations/AvailableTranslations.tsx
@@ -1,0 +1,64 @@
+import React, { Fragment } from 'react';
+import { useBlogContext } from '../blogContext';
+import { Link } from 'gatsby';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { useIntl } from 'context/react-intl';
+import { SitePageContextTranslations } from 'graphql-types';
+import { LocaleValues } from 'src/types/Locales';
+import R from 'ramda';
+import { Phrase, Wrapper } from './styled';
+
+const messages = defineMessages({
+  en: {
+    id: 'languages.en',
+  },
+  pt: {
+    id: 'languages.pt',
+  },
+});
+
+type ExistingTranslation = {
+  lang: NonNullable<SitePageContextTranslations['lang']>;
+  slug: NonNullable<SitePageContextTranslations['slug']>;
+};
+
+type ExistingTranslationsList = ExistingTranslation[];
+
+export const AvailableTranslations = () => {
+  const { translations } = useBlogContext();
+  const { formatMessage, switchLocale } = useIntl();
+
+  if (R.isNil(translations)) {
+    return null;
+  }
+
+  const isLastIndex = (index: number) => {
+    return index === translations.length - 1;
+  };
+
+  const separator = ' • ';
+
+  return (
+    <Wrapper data-testid="blog-available-translations">
+      <Phrase>
+        <span>
+          <FormattedMessage id="blog.availableTranslations.text" />{' '}
+        </span>
+        {(translations as ExistingTranslationsList).map((t, index) => (
+          <Fragment key={t.slug}>
+            <Link
+              to={t.slug}
+              onClick={() => {
+                switchLocale(t.lang as LocaleValues);
+              }}
+              data-testid="blog-available-translations-link"
+            >
+              {formatMessage(messages[t.lang as LocaleValues])}
+            </Link>
+            {!isLastIndex(index) && separator}
+          </Fragment>
+        ))}
+      </Phrase>
+    </Wrapper>
+  );
+};

--- a/src/components/Blog/AvailableTranslations/index.ts
+++ b/src/components/Blog/AvailableTranslations/index.ts
@@ -1,0 +1,1 @@
+export * from './AvailableTranslations';

--- a/src/components/Blog/AvailableTranslations/styled.ts
+++ b/src/components/Blog/AvailableTranslations/styled.ts
@@ -1,0 +1,13 @@
+import { styled } from 'styles/emotion';
+import { Container } from 'components/Ui';
+
+export const Wrapper = Container.withComponent('div');
+
+export const Phrase = styled.p`
+  margin: 0;
+  padding: 1em;
+  background-color: ${({ theme }) => theme.color.infoBox};
+  border: 1px solid ${({ theme }) => theme.color.border};
+  border-radius: 0.75em;
+  font-size: 14px;
+`;

--- a/src/components/Blog/types.ts
+++ b/src/components/Blog/types.ts
@@ -1,18 +1,16 @@
-import { SeriesType, PostSeries, PostEdge, Frontmatter } from '../../types';
+import { SitePageContext } from 'graphql-types';
+import { Frontmatter } from '../../types';
 
 export type BlogPostProps = {
-  pageContext: {
-    nextPost: PostSeries | null;
-    post: PostEdge;
-    series: SeriesType;
-  };
+  pageContext: SitePageContext;
 };
 
 export type BlogPostContext = {
-  series?: SeriesType;
+  series: SitePageContext['series'];
   seriesInfo?: Frontmatter['series'];
   title: Frontmatter['title'];
   subtitle: Frontmatter['subtitle'];
   image: Frontmatter['image'];
   imageCaption: Frontmatter['image_caption'];
+  translations: SitePageContext['translations'];
 };

--- a/src/components/Home/helpers/__test__/data.ts
+++ b/src/components/Home/helpers/__test__/data.ts
@@ -340,7 +340,7 @@ export const getAndSanitizePostsFromQueryResponse = [
       fields: {
         slug: '/en/2019/03/netlifiy-deploy',
         lang: 'en',
-        commonSlug: '/2019/03/netlifiy-deploy',
+        postFolderName: '/2019/03/netlifiy-deploy',
       },
     },
   },
@@ -353,7 +353,7 @@ export const getAndSanitizePostsFromQueryResponse = [
       fields: {
         slug: '/2019/03/netlifiy-deploy',
         lang: 'pt',
-        commonSlug: '/2019/03/netlifiy-deploy',
+        postFolderName: '/2019/03/netlifiy-deploy',
       },
     },
   },
@@ -366,7 +366,7 @@ export const getAndSanitizePostsFromQueryResponse = [
       fields: {
         slug: '/2019/04/things-i-dont-know-2018',
         lang: 'pt',
-        commonSlug: '/2019/04/things-i-dont-know-2018',
+        postFolderName: '/2019/04/things-i-dont-know-2018',
       },
     },
   },
@@ -379,7 +379,7 @@ export const getAndSanitizePostsFromQueryResponse = [
       fields: {
         slug: '/2018/01/css-position',
         lang: 'pt',
-        commonSlug: '/2018/01/css-position',
+        postFolderName: '/2018/01/css-position',
       },
     },
   },

--- a/src/components/Home/helpers/__test__/posts.test.ts
+++ b/src/components/Home/helpers/__test__/posts.test.ts
@@ -66,7 +66,7 @@ describe('fn: getAndSanitizePostsFromQueryResponse', () => {
           fields: {
             slug: '/2019/03/netlifiy-deploy',
             lang: 'pt',
-            commonSlug: '/2019/03/netlifiy-deploy',
+            postFolderName: '/2019/03/netlifiy-deploy',
           },
           translations: [
             {
@@ -85,7 +85,7 @@ describe('fn: getAndSanitizePostsFromQueryResponse', () => {
           fields: {
             slug: '/2019/04/things-i-dont-know-2018',
             lang: 'pt',
-            commonSlug: '/2019/04/things-i-dont-know-2018',
+            postFolderName: '/2019/04/things-i-dont-know-2018',
           },
         },
       },
@@ -98,7 +98,7 @@ describe('fn: getAndSanitizePostsFromQueryResponse', () => {
           fields: {
             slug: '/2018/01/css-position',
             lang: 'pt',
-            commonSlug: '/2018/01/css-position',
+            postFolderName: '/2018/01/css-position',
           },
         },
       },
@@ -123,7 +123,7 @@ describe('fn: getAndSanitizePostsFromQueryResponse', () => {
           fields: {
             slug: '/en/2019/03/netlifiy-deploy',
             lang: 'en',
-            commonSlug: '/2019/03/netlifiy-deploy',
+            postFolderName: '/2019/03/netlifiy-deploy',
           },
           translations: [
             {
@@ -142,7 +142,7 @@ describe('fn: getAndSanitizePostsFromQueryResponse', () => {
           fields: {
             slug: '/2019/04/things-i-dont-know-2018',
             lang: 'pt',
-            commonSlug: '/2019/04/things-i-dont-know-2018',
+            postFolderName: '/2019/04/things-i-dont-know-2018',
           },
         },
       },
@@ -155,7 +155,7 @@ describe('fn: getAndSanitizePostsFromQueryResponse', () => {
           fields: {
             slug: '/2018/01/css-position',
             lang: 'pt',
-            commonSlug: '/2018/01/css-position',
+            postFolderName: '/2018/01/css-position',
           },
         },
       },

--- a/src/components/Home/helpers/posts.ts
+++ b/src/components/Home/helpers/posts.ts
@@ -34,12 +34,12 @@ export const getAndSanitizePostsFromQueryResponse = ({
     return [];
   }
 
-  const postByCommonSlug = R.groupBy(
-    (edge: PostEdge) => edge.node.fields?.commonSlug!,
+  const postByPostFolderName = R.groupBy(
+    (edge: PostEdge) => edge.node.fields?.postFolderName!,
     postEdges,
   );
 
-  const slugPostPairs = R.toPairs(postByCommonSlug);
+  const slugPostPairs = R.toPairs(postByPostFolderName);
 
   const edgesWithTranslations = slugPostPairs.reduce((result, [, posts]) => {
     if (posts.length === 1) {

--- a/src/components/LanguageSwitch.tsx
+++ b/src/components/LanguageSwitch.tsx
@@ -14,10 +14,10 @@ export const LanguageSwitch: React.FC = () => {
       items={
         <>
           <DropdownMenuItem onClick={switchToEnglish}>
-            <FormattedMessage id="locales.en" />
+            <FormattedMessage id="languages.en" />
           </DropdownMenuItem>
           <DropdownMenuItem onClick={switchToPortuguese}>
-            <FormattedMessage id="locales.pt" />
+            <FormattedMessage id="languages.pt" />
           </DropdownMenuItem>
         </>
       }

--- a/src/components/PostCard/PostCard.tsx
+++ b/src/components/PostCard/PostCard.tsx
@@ -24,10 +24,10 @@ type PostCardProps = {
 
 const messages = defineMessages({
   [LOCALES.PT]: {
-    id: 'locales.pt',
+    id: 'languages.pt',
   },
   [LOCALES.EN]: {
-    id: 'locales.en',
+    id: 'languages.en',
   },
 });
 

--- a/src/components/PostCard/PostCard.tsx
+++ b/src/components/PostCard/PostCard.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import React from 'react';
 import * as R from 'ramda';
 import { FormattedMessage, FormattedDate, defineMessages } from 'react-intl';
@@ -14,7 +15,7 @@ import {
 } from './styled';
 import { Tag, Tags } from '../Ui';
 import { PostNode } from '../../types/GraphQL';
-import { LOCALES } from '../../types/Locales';
+import { LOCALES, LocaleValues } from '../../types/Locales';
 import { useIntl } from 'context/react-intl';
 
 type PostCardProps = {
@@ -38,16 +39,21 @@ export const PostCard: React.FC<PostCardProps> = ({ postNode }) => {
   const shouldRenderTags = !R.pipe(R.isNil, R.isEmpty)(tags);
 
   function generateLanguagesText(): string {
-    const firstLanguage = messages[fields?.lang as 'pt' | 'en'];
+    const firstLanguage = messages[fields?.lang as LocaleValues];
+
     function getPostAvailableTranslation(): null | string {
       if (!translations) return null;
+      const postLang = R.head(translations)!.lang as LocaleValues;
 
-      return R.head(translations)!.lang;
+      // TODO: FIX
+      // @ts-ignore
+      return messages[postLang as LocaleValues];
     }
+
     const languages = [firstLanguage, getPostAvailableTranslation()]
       .filter((l) => l)
       .map((l) => formatMessage(l as { id: string }))
-      .join('/');
+      .join(' / ');
 
     return `(${languages})`;
   }

--- a/src/context/react-intl.tsx
+++ b/src/context/react-intl.tsx
@@ -3,11 +3,15 @@ import { IntlProvider, IntlShape, useIntl as officialUseItl } from 'react-intl';
 import flat from 'flat';
 import { useLocalStorage } from 'react-use';
 
-import { LOCALES } from '../types/Locales';
+import { LOCALES, LocaleValues } from '../types/Locales';
 import enMessages from '../locales/en.json';
 import ptMessages from '../locales/pt-br.json';
 
-type CustomIntlShape = { switchToPortuguese(): void; switchToEnglish(): void };
+type CustomIntlShape = {
+  switchToPortuguese(): void;
+  switchToEnglish(): void;
+  switchLocale(nextLocale: LocaleValues): void;
+};
 
 const IntlContext = React.createContext<CustomIntlShape | undefined>(undefined);
 
@@ -45,7 +49,9 @@ export const IntlContextProvider: React.FC = ({ children }) => {
 
   return (
     <IntlProvider locale={language!} messages={messages}>
-      <IntlContext.Provider value={{ switchToPortuguese, switchToEnglish }}>
+      <IntlContext.Provider
+        value={{ switchToPortuguese, switchToEnglish, switchLocale }}
+      >
         {children}
       </IntlContext.Provider>
     </IntlProvider>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -36,7 +36,7 @@
     "title": "All posts for \"{tag}\"",
     "description": "Check all blog posts I've written related to \"{tag}\"."
   },
-  "locales": {
+  "languages": {
     "pt": "Portuguese",
     "en": "English"
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -18,7 +18,10 @@
   },
   "blog": {
     "readTime": "{minutes} min read",
-    "featuredImage": "Featured image"
+    "featuredImage": "Featured image",
+    "availableTranslations": {
+      "text": "Translated into:"
+    }
   },
   "404": {
     "title": "404 - Page not found",

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -36,7 +36,7 @@
     "title": "Posts com a tag \"{tag}\"",
     "description": "Veja todas as tags que escrevi com relacionados com a tag \"{tag}\"."
   },
-  "locales": {
+  "languages": {
     "pt": "Português",
     "en": "Inglês"
   }

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -12,7 +12,10 @@
   },
   "blog": {
     "readTime": "{minutes} min de leitura",
-    "featuredImage": "Imagem de destaque"
+    "featuredImage": "Imagem de destaque",
+    "availableTranslations": {
+      "text": "Traduzido em:"
+    }
   },
   "sideMenu": {
     "home": "Início",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -60,7 +60,7 @@ export const query = graphql`
           fields {
             slug
             lang
-            commonSlug
+            postFolderName
           }
         }
       }

--- a/src/setupTest.ts
+++ b/src/setupTest.ts
@@ -1,1 +1,15 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-empty-function */
 import '@testing-library/jest-dom';
+
+/**
+ * This workaround solves rendering `gatsby/Link` on test env.
+ * https://github.com/gatsbyjs/gatsby/issues/19898#issuecomment-568268318
+ */
+// @ts-ignore
+window.___loader = { enqueue: () => {}, hovering: () => {} };
+
+/**
+ * This is related to `ts-jest`
+ */
+// @ts-ignore
+window.__BASE_PATH__ = '';

--- a/src/styles/emotion.ts
+++ b/src/styles/emotion.ts
@@ -18,6 +18,7 @@ export interface SiteTheme {
     shadowLight: string;
     shadowBright: string;
     shadowMenu: string;
+    infoBox: string;
   };
   sizes: {
     menuBar: {

--- a/src/styles/globals.ts
+++ b/src/styles/globals.ts
@@ -26,6 +26,7 @@ export const customGlobals = css`
     --shadowLight: rgba(0, 0, 0, 0.25);
     --shadowBright: rgba(0, 0, 0, 0.05);
     --shadowMenu: rgba(0, 0, 0, 0.05);
+    --infoBox: #fbf9e0;
   }
 
   body.dark {
@@ -38,6 +39,7 @@ export const customGlobals = css`
     --shadowLight: rgba(255, 255, 255, 0.25);
     --shadowBright: rgba(255, 255, 255, 0.05);
     --shadowMenu: '';
+    --infoBox: #233648;
   }
 
   body {

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -31,6 +31,7 @@ export const theme: Partial<SiteTheme> = {
     shadowLight: 'var(--shadowLight)',
     shadowBright: 'var(--shadowBright)',
     shadowMenu: 'var(--shadowMenu)',
+    infoBox: 'var(--infoBox)',
   },
   sizes: {
     menuBar: {

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -20,6 +20,7 @@ import { ThemeProvider } from '../context/theme';
 import { styled, media, SiteTheme } from 'styles/emotion';
 import { SideMenu } from 'components/SideMenu';
 import { joinSubtitleAndDescription } from 'utils/seo';
+import { AvailableTranslations } from 'components/Blog/AvailableTranslations';
 
 const Main = Container.withComponent('main');
 
@@ -37,8 +38,8 @@ const Article = styled(motion.article)`
 const BlogPost: React.FC<BlogPostProps> = ({ pageContext }) => {
   useTwitterScript();
 
-  const { series, post } = pageContext;
-  const { body, frontmatter, excerpt, fields } = post.node;
+  const { series, post, translations } = pageContext;
+  const { body, frontmatter, excerpt, fields } = post!.node!;
   const {
     image,
     image_caption: imageCaption,
@@ -73,9 +74,18 @@ const BlogPost: React.FC<BlogPostProps> = ({ pageContext }) => {
           variants={pageTransitionVariants}
         >
           <BlogContextProvider
-            value={{ series, seriesInfo, title, subtitle, image, imageCaption }}
+            value={{
+              series,
+              seriesInfo,
+              title,
+              subtitle,
+              image,
+              imageCaption,
+              translations,
+            }}
           >
             <Header />
+            <AvailableTranslations />
             <SeriesSection noDivider />
             <FeaturedImage />
             <Main className="post">

--- a/src/templates/home.tsx
+++ b/src/templates/home.tsx
@@ -29,16 +29,16 @@ type HomeTemplateType = {
 const HomeTemplate: React.FC<HomeTemplateType> = ({ pageContext }) => {
   const { postEdges } = pageContext;
 
-  const { hasMore, loadMore, postsToRender, filter, setFilter } = useHomeState(
-    postEdges,
-  );
-
   const { locale, formatMessage } = useIntl();
 
   const posts = getAndSanitizePostsFromQueryResponse({
-    postEdges: postsToRender,
+    postEdges,
     preferredLang: locale,
   });
+
+  const { hasMore, loadMore, postsToRender, filter, setFilter } = useHomeState(
+    posts,
+  );
 
   return (
     <>
@@ -53,7 +53,7 @@ const HomeTemplate: React.FC<HomeTemplateType> = ({ pageContext }) => {
         <AuthorPresentation />
         <Filter setFilter={setFilter} currentFilter={filter} />
         <Posts
-          posts={posts}
+          posts={postsToRender}
           filter={filter}
           loadMore={loadMore}
           hasMore={hasMore}

--- a/src/types/GraphQL.ts
+++ b/src/types/GraphQL.ts
@@ -24,7 +24,7 @@ export type Frontmatter = {
 type PostFields = {
   slug: string;
   lang?: string;
-  commonSlug?: string;
+  postFolderName?: string;
 };
 
 export type PostTranslation = {

--- a/src/types/Locales.ts
+++ b/src/types/Locales.ts
@@ -2,3 +2,5 @@ export enum LOCALES {
   PT = 'pt',
   EN = 'en',
 }
+
+export type LocaleValues = 'pt' | 'en';

--- a/types/graphql-types.ts
+++ b/types/graphql-types.ts
@@ -1264,7 +1264,7 @@ export type FileFieldsEnum =
   | 'childMdx___wordCount___words'
   | 'childMdx___fields___slug'
   | 'childMdx___fields___lang'
-  | 'childMdx___fields___commonSlug'
+  | 'childMdx___fields___postFolderName'
   | 'childMdx___id'
   | 'childMdx___parent___id'
   | 'childMdx___parent___parent___id'
@@ -2072,7 +2072,7 @@ export type MdxEdge = {
 export type MdxFields = {
   slug?: Maybe<Scalars['String']>;
   lang?: Maybe<Scalars['String']>;
-  commonSlug?: Maybe<Scalars['String']>;
+  postFolderName?: Maybe<Scalars['String']>;
 };
 
 export type MdxFieldsEnum = 
@@ -2164,7 +2164,7 @@ export type MdxFieldsEnum =
   | 'wordCount___words'
   | 'fields___slug'
   | 'fields___lang'
-  | 'fields___commonSlug'
+  | 'fields___postFolderName'
   | 'id'
   | 'parent___id'
   | 'parent___parent___id'
@@ -2255,7 +2255,7 @@ export type MdxFieldsEnum =
 export type MdxFieldsFilterInput = {
   slug?: Maybe<StringQueryOperatorInput>;
   lang?: Maybe<StringQueryOperatorInput>;
-  commonSlug?: Maybe<StringQueryOperatorInput>;
+  postFolderName?: Maybe<StringQueryOperatorInput>;
 };
 
 export type MdxFilterInput = {
@@ -3052,6 +3052,7 @@ export type SitePageContext = {
   post?: Maybe<SitePageContextPost>;
   slug?: Maybe<Scalars['String']>;
   series?: Maybe<SitePageContextSeries>;
+  translations?: Maybe<Array<Maybe<SitePageContextTranslations>>>;
   postEdges?: Maybe<Array<Maybe<SitePageContextPostEdges>>>;
   tag?: Maybe<Scalars['String']>;
 };
@@ -3060,6 +3061,7 @@ export type SitePageContextFilterInput = {
   post?: Maybe<SitePageContextPostFilterInput>;
   slug?: Maybe<StringQueryOperatorInput>;
   series?: Maybe<SitePageContextSeriesFilterInput>;
+  translations?: Maybe<SitePageContextTranslationsFilterListInput>;
   postEdges?: Maybe<SitePageContextPostEdgesFilterListInput>;
   tag?: Maybe<StringQueryOperatorInput>;
 };
@@ -3091,13 +3093,13 @@ export type SitePageContextPostEdgesNode = {
 export type SitePageContextPostEdgesNodeFields = {
   slug?: Maybe<Scalars['String']>;
   lang?: Maybe<Scalars['String']>;
-  commonSlug?: Maybe<Scalars['String']>;
+  postFolderName?: Maybe<Scalars['String']>;
 };
 
 export type SitePageContextPostEdgesNodeFieldsFilterInput = {
   slug?: Maybe<StringQueryOperatorInput>;
   lang?: Maybe<StringQueryOperatorInput>;
-  commonSlug?: Maybe<StringQueryOperatorInput>;
+  postFolderName?: Maybe<StringQueryOperatorInput>;
 };
 
 export type SitePageContextPostEdgesNodeFilterInput = {
@@ -3194,18 +3196,19 @@ export type SitePageContextPostNode = {
   frontmatter?: Maybe<SitePageContextPostNodeFrontmatter>;
   fileAbsolutePath?: Maybe<Scalars['String']>;
   fields?: Maybe<SitePageContextPostNodeFields>;
+  nonGraphQLData?: Maybe<SitePageContextPostNodeNonGraphQlData>;
 };
 
 export type SitePageContextPostNodeFields = {
   slug?: Maybe<Scalars['String']>;
   lang?: Maybe<Scalars['String']>;
-  commonSlug?: Maybe<Scalars['String']>;
+  postFolderName?: Maybe<Scalars['String']>;
 };
 
 export type SitePageContextPostNodeFieldsFilterInput = {
   slug?: Maybe<StringQueryOperatorInput>;
   lang?: Maybe<StringQueryOperatorInput>;
-  commonSlug?: Maybe<StringQueryOperatorInput>;
+  postFolderName?: Maybe<StringQueryOperatorInput>;
 };
 
 export type SitePageContextPostNodeFilterInput = {
@@ -3216,6 +3219,7 @@ export type SitePageContextPostNodeFilterInput = {
   frontmatter?: Maybe<SitePageContextPostNodeFrontmatterFilterInput>;
   fileAbsolutePath?: Maybe<StringQueryOperatorInput>;
   fields?: Maybe<SitePageContextPostNodeFieldsFilterInput>;
+  nonGraphQLData?: Maybe<SitePageContextPostNodeNonGraphQlDataFilterInput>;
 };
 
 export type SitePageContextPostNodeFrontmatter = {
@@ -3298,6 +3302,28 @@ export type SitePageContextPostNodeFrontmatterSeriesFilterInput = {
   id?: Maybe<StringQueryOperatorInput>;
   index?: Maybe<IntQueryOperatorInput>;
   copy?: Maybe<StringQueryOperatorInput>;
+};
+
+export type SitePageContextPostNodeNonGraphQlData = {
+  translations?: Maybe<Array<Maybe<SitePageContextPostNodeNonGraphQlDataTranslations>>>;
+};
+
+export type SitePageContextPostNodeNonGraphQlDataFilterInput = {
+  translations?: Maybe<SitePageContextPostNodeNonGraphQlDataTranslationsFilterListInput>;
+};
+
+export type SitePageContextPostNodeNonGraphQlDataTranslations = {
+  lang?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+};
+
+export type SitePageContextPostNodeNonGraphQlDataTranslationsFilterInput = {
+  lang?: Maybe<StringQueryOperatorInput>;
+  slug?: Maybe<StringQueryOperatorInput>;
+};
+
+export type SitePageContextPostNodeNonGraphQlDataTranslationsFilterListInput = {
+  elemMatch?: Maybe<SitePageContextPostNodeNonGraphQlDataTranslationsFilterInput>;
 };
 
 export type SitePageContextSeries = {
@@ -3482,6 +3508,20 @@ export type SitePageContextSeriesFilterInput = {
   _10?: Maybe<SitePageContextSeries_10FilterInput>;
 };
 
+export type SitePageContextTranslations = {
+  lang?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+};
+
+export type SitePageContextTranslationsFilterInput = {
+  lang?: Maybe<StringQueryOperatorInput>;
+  slug?: Maybe<StringQueryOperatorInput>;
+};
+
+export type SitePageContextTranslationsFilterListInput = {
+  elemMatch?: Maybe<SitePageContextTranslationsFilterInput>;
+};
+
 export type SitePageEdge = {
   next?: Maybe<SitePage>;
   node: SitePage;
@@ -3631,6 +3671,9 @@ export type SitePageFieldsEnum =
   | 'context___series____10___copy'
   | 'context___series____10___index'
   | 'context___series____10___uri'
+  | 'context___translations'
+  | 'context___translations___lang'
+  | 'context___translations___slug'
   | 'context___postEdges'
   | 'context___postEdges___node___id'
   | 'context___postEdges___node___timeToRead'
@@ -4279,7 +4322,7 @@ export type Unnamed_3_Query = { allMdx: { edges: Array<{ node: (
         & { frontmatter?: Maybe<(
           Pick<MdxFrontmatter, 'title' | 'subtitle' | 'date' | 'tags' | 'description'>
           & { series?: Maybe<Pick<MdxFrontmatterSeries, 'id'>>, image?: Maybe<{ childImageSharp?: Maybe<{ fluid?: Maybe<Pick<ImageSharpFluid, 'base64' | 'tracedSVG' | 'srcWebp' | 'srcSetWebp' | 'srcSet' | 'src' | 'sizes' | 'presentationWidth' | 'presentationHeight' | 'originalName' | 'originalImg' | 'aspectRatio'>> }> }> }
-        )>, fields?: Maybe<Pick<MdxFields, 'slug' | 'lang' | 'commonSlug'>> }
+        )>, fields?: Maybe<Pick<MdxFields, 'slug' | 'lang' | 'postFolderName'>> }
       ) }> } };
 
 export type UsesQueryVariables = Exact<{ [key: string]: never; }>;

--- a/types/graphql-types.ts
+++ b/types/graphql-types.ts
@@ -2561,6 +2561,8 @@ export type QueryAllSitePageArgs = {
 export type QuerySiteArgs = {
   buildTime?: Maybe<DateQueryOperatorInput>;
   siteMetadata?: Maybe<SiteSiteMetadataFilterInput>;
+  port?: Maybe<DateQueryOperatorInput>;
+  host?: Maybe<StringQueryOperatorInput>;
   polyfill?: Maybe<BooleanQueryOperatorInput>;
   pathPrefix?: Maybe<StringQueryOperatorInput>;
   id?: Maybe<StringQueryOperatorInput>;
@@ -2695,6 +2697,8 @@ export type QueryAllSitePluginArgs = {
 export type Site = Node & {
   buildTime?: Maybe<Scalars['Date']>;
   siteMetadata?: Maybe<SiteSiteMetadata>;
+  port?: Maybe<Scalars['Date']>;
+  host?: Maybe<Scalars['String']>;
   polyfill?: Maybe<Scalars['Boolean']>;
   pathPrefix?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
@@ -2705,6 +2709,14 @@ export type Site = Node & {
 
 
 export type SiteBuildTimeArgs = {
+  formatString?: Maybe<Scalars['String']>;
+  fromNow?: Maybe<Scalars['Boolean']>;
+  difference?: Maybe<Scalars['String']>;
+  locale?: Maybe<Scalars['String']>;
+};
+
+
+export type SitePortArgs = {
   formatString?: Maybe<Scalars['String']>;
   fromNow?: Maybe<Scalars['Boolean']>;
   difference?: Maybe<Scalars['String']>;
@@ -2901,6 +2913,8 @@ export type SiteFieldsEnum =
   | 'siteMetadata___social___twitter'
   | 'siteMetadata___social___linkedIn'
   | 'siteMetadata___social___github'
+  | 'port'
+  | 'host'
   | 'polyfill'
   | 'pathPrefix'
   | 'id'
@@ -2993,6 +3007,8 @@ export type SiteFieldsEnum =
 export type SiteFilterInput = {
   buildTime?: Maybe<DateQueryOperatorInput>;
   siteMetadata?: Maybe<SiteSiteMetadataFilterInput>;
+  port?: Maybe<DateQueryOperatorInput>;
+  host?: Maybe<StringQueryOperatorInput>;
   polyfill?: Maybe<BooleanQueryOperatorInput>;
   pathPrefix?: Maybe<StringQueryOperatorInput>;
   id?: Maybe<StringQueryOperatorInput>;
@@ -3744,17 +3760,6 @@ export type SitePageFieldsEnum =
   | 'pluginCreator___pluginOptions___aliases___gql'
   | 'pluginCreator___pluginOptions___aliases___mdx'
   | 'pluginCreator___pluginOptions___google___families'
-  | 'pluginCreator___pluginOptions___appId'
-  | 'pluginCreator___pluginOptions___apiKey'
-  | 'pluginCreator___pluginOptions___indexName'
-  | 'pluginCreator___pluginOptions___queries'
-  | 'pluginCreator___pluginOptions___queries___query'
-  | 'pluginCreator___pluginOptions___queries___indexName'
-  | 'pluginCreator___pluginOptions___chunkSize'
-  | 'pluginCreator___pluginOptions___enablePartialUpdates'
-  | 'pluginCreator___pluginOptions___matchFields'
-  | 'pluginCreator___pluginOptions___trackingId'
-  | 'pluginCreator___pluginOptions___head'
   | 'pluginCreator___pluginOptions___pathCheck'
   | 'pluginCreator___nodeAPIs'
   | 'pluginCreator___browserAPIs'
@@ -3967,18 +3972,6 @@ export type SitePluginFieldsEnum =
   | 'pluginOptions___aliases___gql'
   | 'pluginOptions___aliases___mdx'
   | 'pluginOptions___google___families'
-  | 'pluginOptions___appId'
-  | 'pluginOptions___apiKey'
-  | 'pluginOptions___indexName'
-  | 'pluginOptions___queries'
-  | 'pluginOptions___queries___query'
-  | 'pluginOptions___queries___indexName'
-  | 'pluginOptions___queries___settings___attributesToSnippet'
-  | 'pluginOptions___chunkSize'
-  | 'pluginOptions___enablePartialUpdates'
-  | 'pluginOptions___matchFields'
-  | 'pluginOptions___trackingId'
-  | 'pluginOptions___head'
   | 'pluginOptions___pathCheck'
   | 'nodeAPIs'
   | 'browserAPIs'
@@ -4113,15 +4106,6 @@ export type SitePluginPluginOptions = {
   extensions?: Maybe<Array<Maybe<Scalars['String']>>>;
   aliases?: Maybe<SitePluginPluginOptionsAliases>;
   google?: Maybe<SitePluginPluginOptionsGoogle>;
-  appId?: Maybe<Scalars['String']>;
-  apiKey?: Maybe<Scalars['String']>;
-  indexName?: Maybe<Scalars['String']>;
-  queries?: Maybe<Array<Maybe<SitePluginPluginOptionsQueries>>>;
-  chunkSize?: Maybe<Scalars['Int']>;
-  enablePartialUpdates?: Maybe<Scalars['Boolean']>;
-  matchFields?: Maybe<Array<Maybe<Scalars['String']>>>;
-  trackingId?: Maybe<Scalars['String']>;
-  head?: Maybe<Scalars['Boolean']>;
   pathCheck?: Maybe<Scalars['Boolean']>;
 };
 
@@ -4158,15 +4142,6 @@ export type SitePluginPluginOptionsFilterInput = {
   extensions?: Maybe<StringQueryOperatorInput>;
   aliases?: Maybe<SitePluginPluginOptionsAliasesFilterInput>;
   google?: Maybe<SitePluginPluginOptionsGoogleFilterInput>;
-  appId?: Maybe<StringQueryOperatorInput>;
-  apiKey?: Maybe<StringQueryOperatorInput>;
-  indexName?: Maybe<StringQueryOperatorInput>;
-  queries?: Maybe<SitePluginPluginOptionsQueriesFilterListInput>;
-  chunkSize?: Maybe<IntQueryOperatorInput>;
-  enablePartialUpdates?: Maybe<BooleanQueryOperatorInput>;
-  matchFields?: Maybe<StringQueryOperatorInput>;
-  trackingId?: Maybe<StringQueryOperatorInput>;
-  head?: Maybe<BooleanQueryOperatorInput>;
   pathCheck?: Maybe<BooleanQueryOperatorInput>;
 };
 
@@ -4192,30 +4167,6 @@ export type SitePluginPluginOptionsLocalizeFilterInput = {
 
 export type SitePluginPluginOptionsLocalizeFilterListInput = {
   elemMatch?: Maybe<SitePluginPluginOptionsLocalizeFilterInput>;
-};
-
-export type SitePluginPluginOptionsQueries = {
-  query?: Maybe<Scalars['String']>;
-  indexName?: Maybe<Scalars['String']>;
-  settings?: Maybe<SitePluginPluginOptionsQueriesSettings>;
-};
-
-export type SitePluginPluginOptionsQueriesFilterInput = {
-  query?: Maybe<StringQueryOperatorInput>;
-  indexName?: Maybe<StringQueryOperatorInput>;
-  settings?: Maybe<SitePluginPluginOptionsQueriesSettingsFilterInput>;
-};
-
-export type SitePluginPluginOptionsQueriesFilterListInput = {
-  elemMatch?: Maybe<SitePluginPluginOptionsQueriesFilterInput>;
-};
-
-export type SitePluginPluginOptionsQueriesSettings = {
-  attributesToSnippet?: Maybe<Array<Maybe<Scalars['String']>>>;
-};
-
-export type SitePluginPluginOptionsQueriesSettingsFilterInput = {
-  attributesToSnippet?: Maybe<StringQueryOperatorInput>;
 };
 
 export type SitePluginSortInput = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4542,6 +4542,13 @@ browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.12.2, browserslist@^4
     escalade "^3.0.1"
     node-releases "^1.1.58"
 
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -4590,7 +4597,7 @@ buffer-fill@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
   integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
 
-buffer-from@^1.0.0:
+buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -7637,7 +7644,7 @@ fast-glob@^3.0.3, fast-glob@^3.1.1:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -11165,7 +11172,7 @@ jest-snapshot@^26.1.0:
     pretty-format "^26.1.0"
     semver "^7.3.2"
 
-jest-util@^26.1.0:
+jest-util@26.x, jest-util@^26.1.0:
   version "26.1.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.1.0.tgz#80e85d4ba820decacf41a691c2042d5276e5d8d8"
   integrity sha512-rNMOwFQevljfNGvbzNQAxdmXQ+NawW/J72dmddsK0E8vgxXCMtwQ/EH0BiWEIxh0hhMcTsxwAxINt7Lh46Uzbg==
@@ -11352,19 +11359,19 @@ json3@^3.3.2:
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
   integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
 
+json5@2.x, json5@^2.1.2, json5@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
+  integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
+  dependencies:
+    minimist "^1.2.5"
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
-
-json5@^2.1.2, json5@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
-  integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
-  dependencies:
-    minimist "^1.2.5"
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -11771,7 +11778,7 @@ lodash.maxby@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.maxby/-/lodash.maxby-4.6.0.tgz#082240068f3c7a227aa00a8380e4f38cf0786e3d"
   integrity sha1-CCJABo88eiJ6oAqDgOTzjPB4bj0=
 
-lodash.memoize@^4.1.2:
+lodash.memoize@4.x, lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
@@ -12019,6 +12026,11 @@ make-dir@^3.0.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+make-error@1.x:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -12443,17 +12455,17 @@ mkdirp-classic@^0.5.2:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
+mkdirp@1.x, mkdirp@^1.0.3, mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 mkdirp@^0.5, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
-
-mkdirp@^1.0.3, mkdirp@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mobx-react-lite@2, mobx-react-lite@2.0.7:
   version "2.0.7"
@@ -15815,15 +15827,15 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
+semver@7.x, semver@^7.2.1, semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
 semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.2.1, semver@^7.3.2:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 send@0.17.1:
   version "0.17.1"
@@ -17390,6 +17402,22 @@ ts-invariant@^0.4.0:
   dependencies:
     tslib "^1.9.3"
 
+ts-jest@26.1.3:
+  version "26.1.3"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.1.3.tgz#aac928a05fdf13e3e6dfbc8caec3847442667894"
+  integrity sha512-beUTSvuqR9SmKQEylewqJdnXWMVGJRFqSz2M8wKJe7GBMmLZ5zw6XXKSJckbHNMxn+zdB3guN2eOucSw2gBMnw==
+  dependencies:
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "26.x"
+    json5 "2.x"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    mkdirp "1.x"
+    semver "7.x"
+    yargs-parser "18.x"
+
 ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -18839,6 +18867,14 @@ yaml@^1.7.2, yaml@^1.8.3:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
+yargs-parser@18.x, yargs-parser@^18.1.2:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
@@ -18851,14 +18887,6 @@ yargs-parser@^15.0.1:
   version "15.0.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
   integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^18.1.2:
-  version "18.1.3"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
-  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"


### PR DESCRIPTION
## Description

This PR introduces the element to show for available post translations.

Until this point I didn't have a post translated so it didn't make sense of having this feature. But now I need to make easier for the user to navigate between the translations

## Screenshots
![image](https://user-images.githubusercontent.com/12464600/87850520-3def7c00-c8f1-11ea-92d2-5754ecc07780.png)
![image](https://user-images.githubusercontent.com/12464600/87850522-3f20a900-c8f1-11ea-9bed-3f55c36f5e23.png)

