### PR TITLE
fix: change initial animation to enter ou the main layout

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -30,7 +30,7 @@ const Layout: React.FC<LayoutProps> = ({ children, className }) => {
       <MenuBar />
       <Main
         as={motion.main}
-        initial="exit"
+        initial="enter"
         animate="enter"
         exit="exit"
         variants={pageTransitionVariants}


### PR DESCRIPTION
Because I've defined the initial animation for `Main` on Layout would be exit, it implies on having opacity 0:

![ezgif com-crop](https://user-images.githubusercontent.com/12464600/88691976-d1992780-d0fd-11ea-88b8-8eaa503ba9d8.gif)


Just changing the initial value to enter would make the first render faster