### PR TITLE
feat: implement draft system for posts

### DIFF
--- a/projects/server/api/post/controllers/post.js
+++ b/projects/server/api/post/controllers/post.js
@@ -1,8 +1,35 @@
 'use strict';
+const { sanitizeEntity } = require('strapi-utils');
 
 /**
  * Read the documentation (https://strapi.io/documentation/v3.x/concepts/controllers.html#core-controllers)
  * to customize this controller
  */
 
-module.exports = {};
+module.exports = {
+  /**
+   * This is the Draft system.
+   *
+   * I enforce to ONLY send posts which has "published" status
+   * when the route find all or find one be called
+   * https://strapi.io/documentation/v3.x/guides/draft.html#get-the-data-back
+   */
+  async find(ctx) {
+    let entities;
+
+    ctx.query = {
+      ...ctx.query,
+      status: 'Published',
+    };
+
+    if (ctx.query._q) {
+      entities = await strapi.services.post.search(ctx.query);
+    } else {
+      entities = await strapi.services.post.find(ctx.query);
+    }
+
+    return entities.map((entity) =>
+      sanitizeEntity(entity, { model: strapi.models.post }),
+    );
+  },
+};

--- a/projects/server/api/post/models/post.settings.json
+++ b/projects/server/api/post/models/post.settings.json
@@ -68,9 +68,10 @@
       "type": "richtext",
       "maxLength": 300
     },
-    "is_shown": {
-      "type": "boolean",
-      "default": true,
+    "status": {
+      "type": "enumeration",
+      "enum": ["Draft", "Published", "Archived"],
+      "default": "Draft",
       "required": true
     }
   }

--- a/projects/web/gatsby-config.js
+++ b/projects/web/gatsby-config.js
@@ -147,6 +147,7 @@ const plugins = [
   {
     resolve: `gatsby-source-strapi`,
     options: {
+      queryLimit: 1000,
       apiURL: process.env.STRAPI_API_URL || `http://localhost:1337`,
       contentTypes: [`uses`, `posts`, `post-tags`, `post-serie`],
       singleTypes: [`cv`, `personal-information`, `social`, `site`],

--- a/projects/web/helpers/algolia.js
+++ b/projects/web/helpers/algolia.js
@@ -2,7 +2,7 @@ const { blogPostUri } = require('../globalShared/utils');
 
 const myQuery = `
   query BlogPosts {
-    posts: allStrapiPosts(sort: {fields: date, order: DESC}, limit: 1000, filter: {is_shown: {eq: true}}) {
+    posts: allStrapiPosts(sort: {fields: date, order: DESC}, limit: 1000) {
       nodes {
         objectID: id
         language

--- a/projects/web/helpers/createPages.js
+++ b/projects/web/helpers/createPages.js
@@ -9,11 +9,7 @@ const tagTemplate = path.resolve('./src/screens/Tag/PageTemplate.tsx');
 async function createBlogPost({ graphql, createPage }) {
   const result = await graphql(`
     query BlogPosts {
-      posts: allStrapiPosts(
-        sort: { fields: date, order: DESC }
-        limit: 1000
-        filter: { is_shown: { eq: true } }
-      ) {
+      posts: allStrapiPosts(sort: { fields: date, order: DESC }, limit: 1000) {
         nodes {
           ...BlogPost
         }
@@ -154,11 +150,7 @@ async function createTagPage({ graphql, createPage }) {
           }
         }
       }
-      posts: allStrapiPosts(
-        sort: { fields: date, order: DESC }
-        limit: 1000
-        filter: { is_shown: { eq: true } }
-      ) {
+      posts: allStrapiPosts(sort: { fields: date, order: DESC }, limit: 1000) {
         nodes {
           ...BlogPost
         }

--- a/projects/web/src/pages/index.tsx
+++ b/projects/web/src/pages/index.tsx
@@ -44,11 +44,7 @@ const Home: React.FC<HomeProps> = ({ data }) => {
 
 export const query = graphql`
   query BlogPosts {
-    posts: allStrapiPosts(
-      sort: { fields: date, order: DESC }
-      limit: 1000
-      filter: { is_shown: { eq: true } }
-    ) {
+    posts: allStrapiPosts(sort: { fields: date, order: DESC }, limit: 1000) {
       nodes {
         ...BlogPost
       }

--- a/projects/web/types/graphql-types.ts
+++ b/projects/web/types/graphql-types.ts
@@ -1722,15 +1722,15 @@ export type QuerySitePageArgs = {
   internalComponentName?: Maybe<StringQueryOperatorInput>;
   componentChunkName?: Maybe<StringQueryOperatorInput>;
   matchPath?: Maybe<StringQueryOperatorInput>;
-  id?: Maybe<StringQueryOperatorInput>;
-  parent?: Maybe<NodeFilterInput>;
-  children?: Maybe<NodeFilterListInput>;
-  internal?: Maybe<InternalFilterInput>;
   isCreatedByStatefulCreatePages?: Maybe<BooleanQueryOperatorInput>;
   context?: Maybe<SitePageContextFilterInput>;
   pluginCreator?: Maybe<SitePluginFilterInput>;
   pluginCreatorId?: Maybe<StringQueryOperatorInput>;
   componentPath?: Maybe<StringQueryOperatorInput>;
+  id?: Maybe<StringQueryOperatorInput>;
+  parent?: Maybe<NodeFilterInput>;
+  children?: Maybe<NodeFilterListInput>;
+  internal?: Maybe<InternalFilterInput>;
 };
 
 
@@ -1746,8 +1746,6 @@ export type QuerySiteArgs = {
   buildTime?: Maybe<DateQueryOperatorInput>;
   port?: Maybe<IntQueryOperatorInput>;
   host?: Maybe<StringQueryOperatorInput>;
-  polyfill?: Maybe<BooleanQueryOperatorInput>;
-  pathPrefix?: Maybe<StringQueryOperatorInput>;
   id?: Maybe<StringQueryOperatorInput>;
   parent?: Maybe<NodeFilterInput>;
   children?: Maybe<NodeFilterListInput>;
@@ -2007,8 +2005,9 @@ export type QueryStrapiPostsArgs = {
   children?: Maybe<NodeFilterListInput>;
   internal?: Maybe<InternalFilterInput>;
   language?: Maybe<StringQueryOperatorInput>;
-  is_shown?: Maybe<BooleanQueryOperatorInput>;
+  status?: Maybe<StringQueryOperatorInput>;
   post_tags?: Maybe<StrapiPostsPost_TagsFilterListInput>;
+  is_shown?: Maybe<BooleanQueryOperatorInput>;
   slug?: Maybe<StringQueryOperatorInput>;
   date?: Maybe<DateQueryOperatorInput>;
   featured_image_caption?: Maybe<StringQueryOperatorInput>;
@@ -2106,8 +2105,6 @@ export type Site = Node & {
   buildTime?: Maybe<Scalars['Date']>;
   port?: Maybe<Scalars['Int']>;
   host?: Maybe<Scalars['String']>;
-  polyfill?: Maybe<Scalars['Boolean']>;
-  pathPrefix?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   parent?: Maybe<Node>;
   children: Array<Node>;
@@ -2307,8 +2304,6 @@ export type SiteFieldsEnum =
   | 'buildTime'
   | 'port'
   | 'host'
-  | 'polyfill'
-  | 'pathPrefix'
   | 'id'
   | 'parent___id'
   | 'parent___parent___id'
@@ -2400,8 +2395,6 @@ export type SiteFilterInput = {
   buildTime?: Maybe<DateQueryOperatorInput>;
   port?: Maybe<IntQueryOperatorInput>;
   host?: Maybe<StringQueryOperatorInput>;
-  polyfill?: Maybe<BooleanQueryOperatorInput>;
-  pathPrefix?: Maybe<StringQueryOperatorInput>;
   id?: Maybe<StringQueryOperatorInput>;
   parent?: Maybe<NodeFilterInput>;
   children?: Maybe<NodeFilterListInput>;
@@ -2423,15 +2416,15 @@ export type SitePage = Node & {
   internalComponentName: Scalars['String'];
   componentChunkName: Scalars['String'];
   matchPath?: Maybe<Scalars['String']>;
-  id: Scalars['ID'];
-  parent?: Maybe<Node>;
-  children: Array<Node>;
-  internal: Internal;
   isCreatedByStatefulCreatePages?: Maybe<Scalars['Boolean']>;
   context?: Maybe<SitePageContext>;
   pluginCreator?: Maybe<SitePlugin>;
   pluginCreatorId?: Maybe<Scalars['String']>;
   componentPath?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  parent?: Maybe<Node>;
+  children: Array<Node>;
+  internal: Internal;
 };
 
 export type SitePageConnection = {
@@ -2487,6 +2480,14 @@ export type SitePageContextPost = {
   featuredImage?: Maybe<SitePageContextPostFeaturedImage>;
   childStrapiPostContent?: Maybe<SitePageContextPostChildStrapiPostContent>;
   tags?: Maybe<Array<Maybe<SitePageContextPostTags>>>;
+};
+
+
+export type SitePageContextPostDateArgs = {
+  formatString?: Maybe<Scalars['String']>;
+  fromNow?: Maybe<Scalars['Boolean']>;
+  difference?: Maybe<Scalars['String']>;
+  locale?: Maybe<Scalars['String']>;
 };
 
 export type SitePageContextPostChildStrapiPostContent = {
@@ -2593,6 +2594,14 @@ export type SitePageContextPosts = {
   featuredImage?: Maybe<SitePageContextPostsFeaturedImage>;
   childStrapiPostContent?: Maybe<SitePageContextPostsChildStrapiPostContent>;
   tags?: Maybe<Array<Maybe<SitePageContextPostsTags>>>;
+};
+
+
+export type SitePageContextPostsDateArgs = {
+  formatString?: Maybe<Scalars['String']>;
+  fromNow?: Maybe<Scalars['Boolean']>;
+  difference?: Maybe<Scalars['String']>;
+  locale?: Maybe<Scalars['String']>;
 };
 
 export type SitePageContextPostsChildStrapiPostContent = {
@@ -2829,92 +2838,6 @@ export type SitePageFieldsEnum =
   | 'internalComponentName'
   | 'componentChunkName'
   | 'matchPath'
-  | 'id'
-  | 'parent___id'
-  | 'parent___parent___id'
-  | 'parent___parent___parent___id'
-  | 'parent___parent___parent___children'
-  | 'parent___parent___children'
-  | 'parent___parent___children___id'
-  | 'parent___parent___children___children'
-  | 'parent___parent___internal___content'
-  | 'parent___parent___internal___contentDigest'
-  | 'parent___parent___internal___description'
-  | 'parent___parent___internal___fieldOwners'
-  | 'parent___parent___internal___ignoreType'
-  | 'parent___parent___internal___mediaType'
-  | 'parent___parent___internal___owner'
-  | 'parent___parent___internal___type'
-  | 'parent___children'
-  | 'parent___children___id'
-  | 'parent___children___parent___id'
-  | 'parent___children___parent___children'
-  | 'parent___children___children'
-  | 'parent___children___children___id'
-  | 'parent___children___children___children'
-  | 'parent___children___internal___content'
-  | 'parent___children___internal___contentDigest'
-  | 'parent___children___internal___description'
-  | 'parent___children___internal___fieldOwners'
-  | 'parent___children___internal___ignoreType'
-  | 'parent___children___internal___mediaType'
-  | 'parent___children___internal___owner'
-  | 'parent___children___internal___type'
-  | 'parent___internal___content'
-  | 'parent___internal___contentDigest'
-  | 'parent___internal___description'
-  | 'parent___internal___fieldOwners'
-  | 'parent___internal___ignoreType'
-  | 'parent___internal___mediaType'
-  | 'parent___internal___owner'
-  | 'parent___internal___type'
-  | 'children'
-  | 'children___id'
-  | 'children___parent___id'
-  | 'children___parent___parent___id'
-  | 'children___parent___parent___children'
-  | 'children___parent___children'
-  | 'children___parent___children___id'
-  | 'children___parent___children___children'
-  | 'children___parent___internal___content'
-  | 'children___parent___internal___contentDigest'
-  | 'children___parent___internal___description'
-  | 'children___parent___internal___fieldOwners'
-  | 'children___parent___internal___ignoreType'
-  | 'children___parent___internal___mediaType'
-  | 'children___parent___internal___owner'
-  | 'children___parent___internal___type'
-  | 'children___children'
-  | 'children___children___id'
-  | 'children___children___parent___id'
-  | 'children___children___parent___children'
-  | 'children___children___children'
-  | 'children___children___children___id'
-  | 'children___children___children___children'
-  | 'children___children___internal___content'
-  | 'children___children___internal___contentDigest'
-  | 'children___children___internal___description'
-  | 'children___children___internal___fieldOwners'
-  | 'children___children___internal___ignoreType'
-  | 'children___children___internal___mediaType'
-  | 'children___children___internal___owner'
-  | 'children___children___internal___type'
-  | 'children___internal___content'
-  | 'children___internal___contentDigest'
-  | 'children___internal___description'
-  | 'children___internal___fieldOwners'
-  | 'children___internal___ignoreType'
-  | 'children___internal___mediaType'
-  | 'children___internal___owner'
-  | 'children___internal___type'
-  | 'internal___content'
-  | 'internal___contentDigest'
-  | 'internal___description'
-  | 'internal___fieldOwners'
-  | 'internal___ignoreType'
-  | 'internal___mediaType'
-  | 'internal___owner'
-  | 'internal___type'
   | 'isCreatedByStatefulCreatePages'
   | 'context___postUri'
   | 'context___post___id'
@@ -3066,7 +2989,93 @@ export type SitePageFieldsEnum =
   | 'pluginCreator___packageJson___peerDependencies___version'
   | 'pluginCreator___packageJson___keywords'
   | 'pluginCreatorId'
-  | 'componentPath';
+  | 'componentPath'
+  | 'id'
+  | 'parent___id'
+  | 'parent___parent___id'
+  | 'parent___parent___parent___id'
+  | 'parent___parent___parent___children'
+  | 'parent___parent___children'
+  | 'parent___parent___children___id'
+  | 'parent___parent___children___children'
+  | 'parent___parent___internal___content'
+  | 'parent___parent___internal___contentDigest'
+  | 'parent___parent___internal___description'
+  | 'parent___parent___internal___fieldOwners'
+  | 'parent___parent___internal___ignoreType'
+  | 'parent___parent___internal___mediaType'
+  | 'parent___parent___internal___owner'
+  | 'parent___parent___internal___type'
+  | 'parent___children'
+  | 'parent___children___id'
+  | 'parent___children___parent___id'
+  | 'parent___children___parent___children'
+  | 'parent___children___children'
+  | 'parent___children___children___id'
+  | 'parent___children___children___children'
+  | 'parent___children___internal___content'
+  | 'parent___children___internal___contentDigest'
+  | 'parent___children___internal___description'
+  | 'parent___children___internal___fieldOwners'
+  | 'parent___children___internal___ignoreType'
+  | 'parent___children___internal___mediaType'
+  | 'parent___children___internal___owner'
+  | 'parent___children___internal___type'
+  | 'parent___internal___content'
+  | 'parent___internal___contentDigest'
+  | 'parent___internal___description'
+  | 'parent___internal___fieldOwners'
+  | 'parent___internal___ignoreType'
+  | 'parent___internal___mediaType'
+  | 'parent___internal___owner'
+  | 'parent___internal___type'
+  | 'children'
+  | 'children___id'
+  | 'children___parent___id'
+  | 'children___parent___parent___id'
+  | 'children___parent___parent___children'
+  | 'children___parent___children'
+  | 'children___parent___children___id'
+  | 'children___parent___children___children'
+  | 'children___parent___internal___content'
+  | 'children___parent___internal___contentDigest'
+  | 'children___parent___internal___description'
+  | 'children___parent___internal___fieldOwners'
+  | 'children___parent___internal___ignoreType'
+  | 'children___parent___internal___mediaType'
+  | 'children___parent___internal___owner'
+  | 'children___parent___internal___type'
+  | 'children___children'
+  | 'children___children___id'
+  | 'children___children___parent___id'
+  | 'children___children___parent___children'
+  | 'children___children___children'
+  | 'children___children___children___id'
+  | 'children___children___children___children'
+  | 'children___children___internal___content'
+  | 'children___children___internal___contentDigest'
+  | 'children___children___internal___description'
+  | 'children___children___internal___fieldOwners'
+  | 'children___children___internal___ignoreType'
+  | 'children___children___internal___mediaType'
+  | 'children___children___internal___owner'
+  | 'children___children___internal___type'
+  | 'children___internal___content'
+  | 'children___internal___contentDigest'
+  | 'children___internal___description'
+  | 'children___internal___fieldOwners'
+  | 'children___internal___ignoreType'
+  | 'children___internal___mediaType'
+  | 'children___internal___owner'
+  | 'children___internal___type'
+  | 'internal___content'
+  | 'internal___contentDigest'
+  | 'internal___description'
+  | 'internal___fieldOwners'
+  | 'internal___ignoreType'
+  | 'internal___mediaType'
+  | 'internal___owner'
+  | 'internal___type';
 
 export type SitePageFilterInput = {
   path?: Maybe<StringQueryOperatorInput>;
@@ -3074,15 +3083,15 @@ export type SitePageFilterInput = {
   internalComponentName?: Maybe<StringQueryOperatorInput>;
   componentChunkName?: Maybe<StringQueryOperatorInput>;
   matchPath?: Maybe<StringQueryOperatorInput>;
-  id?: Maybe<StringQueryOperatorInput>;
-  parent?: Maybe<NodeFilterInput>;
-  children?: Maybe<NodeFilterListInput>;
-  internal?: Maybe<InternalFilterInput>;
   isCreatedByStatefulCreatePages?: Maybe<BooleanQueryOperatorInput>;
   context?: Maybe<SitePageContextFilterInput>;
   pluginCreator?: Maybe<SitePluginFilterInput>;
   pluginCreatorId?: Maybe<StringQueryOperatorInput>;
   componentPath?: Maybe<StringQueryOperatorInput>;
+  id?: Maybe<StringQueryOperatorInput>;
+  parent?: Maybe<NodeFilterInput>;
+  children?: Maybe<NodeFilterListInput>;
+  internal?: Maybe<InternalFilterInput>;
 };
 
 export type SitePageGroupConnection = {
@@ -4780,8 +4789,9 @@ export type StrapiPosts = Node & {
   children: Array<Node>;
   internal: Internal;
   language?: Maybe<Scalars['String']>;
-  is_shown?: Maybe<Scalars['Boolean']>;
+  status?: Maybe<Scalars['String']>;
   post_tags?: Maybe<Array<Maybe<StrapiPostsPost_Tags>>>;
+  is_shown?: Maybe<Scalars['Boolean']>;
   slug?: Maybe<Scalars['String']>;
   date?: Maybe<Scalars['Date']>;
   featured_image_caption?: Maybe<Scalars['String']>;
@@ -4918,8 +4928,9 @@ export type StrapiPostSerieUpdatedAtArgs = {
 
 export type StrapiPostSerieBlog_Posts = {
   language?: Maybe<Scalars['String']>;
-  is_shown?: Maybe<Scalars['Boolean']>;
+  status?: Maybe<Scalars['String']>;
   post_tags?: Maybe<Array<Maybe<Scalars['String']>>>;
+  is_shown?: Maybe<Scalars['Boolean']>;
   slug?: Maybe<Scalars['String']>;
   date?: Maybe<Scalars['Date']>;
   subtitle?: Maybe<Scalars['String']>;
@@ -4963,8 +4974,9 @@ export type StrapiPostSerieBlog_PostsUpdatedAtArgs = {
 
 export type StrapiPostSerieBlog_PostsFilterInput = {
   language?: Maybe<StringQueryOperatorInput>;
-  is_shown?: Maybe<BooleanQueryOperatorInput>;
+  status?: Maybe<StringQueryOperatorInput>;
   post_tags?: Maybe<StringQueryOperatorInput>;
+  is_shown?: Maybe<BooleanQueryOperatorInput>;
   slug?: Maybe<StringQueryOperatorInput>;
   date?: Maybe<DateQueryOperatorInput>;
   subtitle?: Maybe<StringQueryOperatorInput>;
@@ -5149,8 +5161,9 @@ export type StrapiPostSerieFieldsEnum =
   | 'post_tags'
   | 'blog_posts'
   | 'blog_posts___language'
-  | 'blog_posts___is_shown'
+  | 'blog_posts___status'
   | 'blog_posts___post_tags'
+  | 'blog_posts___is_shown'
   | 'blog_posts___slug'
   | 'blog_posts___date'
   | 'blog_posts___subtitle'
@@ -5366,7 +5379,7 @@ export type StrapiPostsFieldsEnum =
   | 'internal___owner'
   | 'internal___type'
   | 'language'
-  | 'is_shown'
+  | 'status'
   | 'post_tags'
   | 'post_tags___tag'
   | 'post_tags___createdAt'
@@ -5376,6 +5389,7 @@ export type StrapiPostsFieldsEnum =
   | 'post_tags___slug'
   | 'post_tags___name'
   | 'post_tags___id'
+  | 'is_shown'
   | 'slug'
   | 'date'
   | 'featured_image_caption'
@@ -5544,8 +5558,9 @@ export type StrapiPostsFieldsEnum =
   | 'post_serie___id'
   | 'post_serie___post_tags'
   | 'translation___language'
-  | 'translation___is_shown'
+  | 'translation___status'
   | 'translation___post_tags'
+  | 'translation___is_shown'
   | 'translation___slug'
   | 'translation___date'
   | 'translation___subtitle'
@@ -5681,8 +5696,9 @@ export type StrapiPostsFilterInput = {
   children?: Maybe<NodeFilterListInput>;
   internal?: Maybe<InternalFilterInput>;
   language?: Maybe<StringQueryOperatorInput>;
-  is_shown?: Maybe<BooleanQueryOperatorInput>;
+  status?: Maybe<StringQueryOperatorInput>;
   post_tags?: Maybe<StrapiPostsPost_TagsFilterListInput>;
+  is_shown?: Maybe<BooleanQueryOperatorInput>;
   slug?: Maybe<StringQueryOperatorInput>;
   date?: Maybe<DateQueryOperatorInput>;
   featured_image_caption?: Maybe<StringQueryOperatorInput>;
@@ -5798,8 +5814,9 @@ export type StrapiPostsSortInput = {
 
 export type StrapiPostsTranslation = {
   language?: Maybe<Scalars['String']>;
-  is_shown?: Maybe<Scalars['Boolean']>;
+  status?: Maybe<Scalars['String']>;
   post_tags?: Maybe<Array<Maybe<Scalars['String']>>>;
+  is_shown?: Maybe<Scalars['Boolean']>;
   slug?: Maybe<Scalars['String']>;
   date?: Maybe<Scalars['Date']>;
   subtitle?: Maybe<Scalars['String']>;
@@ -5840,8 +5857,9 @@ export type StrapiPostsTranslationUpdatedAtArgs = {
 
 export type StrapiPostsTranslationFilterInput = {
   language?: Maybe<StringQueryOperatorInput>;
-  is_shown?: Maybe<BooleanQueryOperatorInput>;
+  status?: Maybe<StringQueryOperatorInput>;
   post_tags?: Maybe<StringQueryOperatorInput>;
+  is_shown?: Maybe<BooleanQueryOperatorInput>;
   slug?: Maybe<StringQueryOperatorInput>;
   date?: Maybe<DateQueryOperatorInput>;
   subtitle?: Maybe<StringQueryOperatorInput>;
@@ -5922,8 +5940,9 @@ export type StrapiPostTagsUpdatedAtArgs = {
 
 export type StrapiPostTagsBlog_Posts = {
   language?: Maybe<Scalars['String']>;
-  is_shown?: Maybe<Scalars['Boolean']>;
+  status?: Maybe<Scalars['String']>;
   post_tags?: Maybe<Array<Maybe<Scalars['String']>>>;
+  is_shown?: Maybe<Scalars['Boolean']>;
   slug?: Maybe<Scalars['String']>;
   date?: Maybe<Scalars['Date']>;
   featured_image_caption?: Maybe<Scalars['String']>;
@@ -5968,8 +5987,9 @@ export type StrapiPostTagsBlog_PostsUpdatedAtArgs = {
 
 export type StrapiPostTagsBlog_PostsFilterInput = {
   language?: Maybe<StringQueryOperatorInput>;
-  is_shown?: Maybe<BooleanQueryOperatorInput>;
+  status?: Maybe<StringQueryOperatorInput>;
   post_tags?: Maybe<StringQueryOperatorInput>;
+  is_shown?: Maybe<BooleanQueryOperatorInput>;
   slug?: Maybe<StringQueryOperatorInput>;
   date?: Maybe<DateQueryOperatorInput>;
   featured_image_caption?: Maybe<StringQueryOperatorInput>;
@@ -6155,8 +6175,9 @@ export type StrapiPostTagsFieldsEnum =
   | 'name'
   | 'blog_posts'
   | 'blog_posts___language'
-  | 'blog_posts___is_shown'
+  | 'blog_posts___status'
   | 'blog_posts___post_tags'
+  | 'blog_posts___is_shown'
   | 'blog_posts___slug'
   | 'blog_posts___date'
   | 'blog_posts___featured_image_caption'


### PR DESCRIPTION
Reading Strapi docs, I encountered a better way to hide WIP posts: the draft system.

It consists in creating an enum field for the content type and in the `find` method inside the type's controller, adding a proxy code where we enforce a via context.query the status we want to (always the `published` status).

Doing that I don't need the `is_shown` attribute anymore and also can remove any filter from my client-side queries.