### PR TITLE
fix: remove useEffect from page

### DIFF
--- a/projects/web/src/pages/index.tsx
+++ b/projects/web/src/pages/index.tsx
@@ -23,15 +23,13 @@ const store = PostsStore.create({
 });
 
 const Home: React.FC<HomeProps> = ({ data }) => {
-  React.useEffect(() => {
-    const posts = R.path(['posts', 'nodes'], data) as StrapiPosts[];
-    const tags = R.path(['tags', 'nodes'], data) as StrapiPostTags[];
-    const series = R.path(['series', 'nodes'], data) as StrapiPostSerie[];
+  const posts = R.path(['posts', 'nodes'], data) as StrapiPosts[];
+  const tags = R.path(['tags', 'nodes'], data) as StrapiPostTags[];
+  const series = R.path(['series', 'nodes'], data) as StrapiPostSerie[];
 
-    store.apiData.setPosts(posts);
-    store.apiData.setTags(tags);
-    store.apiData.setSeries(series);
-  }, []);
+  store.apiData.setPosts(posts);
+  store.apiData.setTags(tags);
+  store.apiData.setSeries(series);
 
   return (
     <HomeTemplate


### PR DESCRIPTION
The reason I'm removing this is because with gatsby I don't need to wait for data.

Having an `useEffect` with a didMount behaviou there is totally pointless and make the page shows initially a "I don't have state" data and then "now I have", which isn't true since it's built in the server.